### PR TITLE
Remove kirby metadata from protocol docs - Partially closes #37

### DIFF
--- a/blocks/blocks.md
+++ b/blocks/blocks.md
@@ -1,29 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-07-17
-
-----
-
-Metadescription: This section of the Lisk Protocol reviews technical details about our Block Headers, Block Payload and Block Generation.
-
-----
-
-Metakeywords: block generation, block header
-
-----
-
-Title: Blocks
-
-----
-
-Content: 
-
 # Lisk Blocks 
 
 A blockchain is composed of blocks. Each block is composed of a header and a list of transactions. When a delegate is assigned a slot in a delegate round, and has their node running, that delegate generates the next block and confirms up to 25 transactions from the transaction pool. These confirmed transactions will be added to the payload of the block and subsequently signed by the delegate.
@@ -93,35 +67,3 @@ The maximum size of a block payload can then be determined as 58150 bytes if eve
 ## Block Generation
 
 Block generation occurs every 10 seconds within the Lisk network using a DPoS (Delegated Proof of Stake) consensus protocol. Delegates further use [broadhash consensus](/documentation/lisk-protocol/consensus#broadhash-consensus) as a guidance strategy to generate the block in order to prevent forks in the network.
-
-----
-
-Opengraphtitle: Lisk Protocol - Blocks & Block Generation | Lisk Documentation
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Blocks & Block Generation
-
-----
-
-Whatsnext: asusual
-
-----
-
-Whatsnextheadline: 
-
-----
-
-Whatsnextpagelinktext: 
-
-----
-
-Whatsnextpagelink: 

--- a/consensus/consensus.md
+++ b/consensus/consensus.md
@@ -1,29 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-07-10
-
-----
-
-Metadescription: Consensus is a critical aspect of any blockchain system. Lisk utilizes Delegated Proof of Stake (DPoS) as the consensus algorithm to maintain the network.
-
-----
-
-Metakeywords: Consensus Algorithm, DPoS
-
-----
-
-Title: Consensus Algorithm
-
-----
-
-Content: 
-
 # Lisk's Consensus Algorithm
 
 Lisk uses Delegated Proof of Stake ([DPoS](https://lisk.io/academy/blockchain-basics/how-does-blockchain-work/delegated-proof-of-stake/)) as its consensus protocol. 
@@ -80,35 +54,3 @@ The block reward linearly decreases over the lifetime of the network, providing 
 The second incentive provided by the system comes in the form of round fees. A delegate round, described above, comes to a close after the number of specified blocks have been generated. During the closure process, all transactional fees are aggregated and subsequently split between all active participants in the round. These fees can provide reward for each participant apart from the block generation reward, provided there is significant transactional activity in the system.
 
 It is possible for a delegate to forge more than one block within a single round earning more block rewards. In most circumstances this will not occur, however occasionally a delegate node may be offline during the delegate's assigned slot and subsequently will not generate a block. This forces another delegate to step in and generate the block at the end of the round.
-
-----
-
-Opengraphtitle: Lisk Protocol - Consensus Algorithm
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Consensus Algorithm | Lisk Documentation
-
-----
-
-Whatsnext: asusual
-
-----
-
-Whatsnextheadline: 
-
-----
-
-Whatsnextpagelinktext: 
-
-----
-
-Whatsnextpagelink: 

--- a/deprecated-transactions/deprecated-transactions.md
+++ b/deprecated-transactions/deprecated-transactions.md
@@ -1,31 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-06-23
-
-----
-
-Metadescription: This section of the Lisk Protocol documents deprecated transaction types that are no longer supported, but still active within the system.
-
-----
-
-Metakeywords: deprecated transactions
-
-----
-
-Title: Deprecated Transactions
-
-----
-
-Content: 
-
----
-
 ##Deprecated Transactions
 
 This section acts as historical documentation and is presented for transaction types that are no longer supported, but still active within the system. These transactions refer to legacy applications support and should not be used. 
@@ -152,21 +124,3 @@ The following is a representation of the resulting JSON object that will be broa
     ...
 }
 ```
-
-The final size of the transaction, with the signature, is 157 bytes. With a second signature it will be 221 bytes.
-
-----
-
-Opengraphtitle: Lisk Protocol - Deprecated Transactions
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Deprecated Transactions | Lisk Documentation

--- a/deprecated-transactions/deprecated-transactions.md
+++ b/deprecated-transactions/deprecated-transactions.md
@@ -124,3 +124,4 @@ The following is a representation of the resulting JSON object that will be broa
     ...
 }
 ```
+The final size of the transaction, with the signature, is 157 bytes. With a second signature it will be 221 bytes.

--- a/network-rewards/network-rewards.md
+++ b/network-rewards/network-rewards.md
@@ -1,31 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-06-25
-
-----
-
-Metadescription: In order to provide an incentive for securing the network, forging rewards and transaction fees are distributed equally among the active delegates.
-
-----
-
-Metakeywords: network rewards, forging
-
-----
-
-Title: Network Rewards & Forging
-
-----
-
-Content: 
-
----
-
 ##Network Rewards
 
 In order to  incentivise delegates to secure the Lisk network, transaction fees are distributed equally among the active delegates. In addition, a block generation reward, also known as a forging reward, is distributed to each block generator.
@@ -56,19 +28,3 @@ The block reward linearly decreases over the lifetime of the network, providing 
 The second incentive provided by the system comes in the form of round fees. A round comes to a close after the number of specified blocks has been generated. During this closure process, all transactional fees are aggregated and subsequently split between all active participants in the round. These fees can provide significant reward for each participant outside of the block generation reward, provided there is significant transactional activity on the network.
 
 It also is possible for a delegate to earn multiple shares of these fees. This may occur if a delegate forges multiple blocks within a round. In most circumstances this will not happen, however occasionally a delegate node may be offline during that delegate's assigned slot and will therefore be unable to generate a block for their assigned slot. This means that the delegate misses their slot and another delegate will generate multiple blocks during that particular round instead.
-
-----
-
-Opengraphtitle: Lisk Protocol - Network Rewards & Forging
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Network Rewards & Forging | Lisk Documentation

--- a/peer-to-peer-communication/p2p-comunication.md
+++ b/peer-to-peer-communication/p2p-comunication.md
@@ -1,29 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-07-17
-
-----
-
-Metadescription: Peer-to-Peer Communication serves a vital role on the Lisk network. The peering mechanisms provide the required architecture to facilitate network consensus.
-
-----
-
-Metakeywords: Peer-to-Peer Communication
-
-----
-
-Title: Peer-to-Peer Communication
-
-----
-
-Content: 
-
 # Lisk Peer-to-Peer Communication
 
 Peer-to-Peer communication serves a vital function within the Lisk network. The peering mechanisms provide the required architecture to facilitate network consensus, block propagation and transaction propagation.
@@ -63,35 +37,3 @@ Transactions must move from one node to all other nodes in order to be included 
 ##Transaction Pool
 
 The transaction pool provides the Lisk network a robust solution for preserving unconfirmed transactions that have overflowed into the next block. As described in  [**blocks**](/documentation/lisk-protocol/blocks), each block can only include 25 transactions and the transaction pool allows up to 1.000 multisignature transactions and other 1.000 for the remaining transaction types to remain queued for the next block(s). The transaction pool could be thought of as a memory pool, keeping transactions ready until they are signed into a block. The second usage of the transaction pool is to provide a mechanism for propagating transactions. When a node prepares a transaction bundle, it draws up to 25 transactions from the pool and broadcast them to the network. In order to keep the transaction pool tidy, all transactions are given a time to live. This time to live is defined as 10800 seconds, or 1080 blocks. The final use for the transaction pool is to house transactions with pending signatures. Like unconfirmed transactions, these transactions will expire out of the pool based on the lifetime specified when the transaction is first received.
-
-----
-
-Opengraphtitle: Lisk Protocol - Peer-to-Peer Communication
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Peer-to-Peer Communication | Lisk Documentation
-
-----
-
-Whatsnext: asusual
-
-----
-
-Whatsnextheadline: 
-
-----
-
-Whatsnextpagelinktext: 
-
-----
-
-Whatsnextpagelink: 

--- a/security/security.md
+++ b/security/security.md
@@ -1,29 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-07-17
-
-----
-
-Metadescription: Lisk uses cryptographic hashing in order to secure all aspects of the system. EdDSA provides a fast mechanism for hashing and providing security.
-
-----
-
-Metakeywords: Security, key pair
-
-----
-
-Title: Security
-
-----
-
-Content: 
-
 # Lisk Security
 
 Lisk uses elliptic curve cryptography and cryptographic hashing in order to secure all aspects of the system. The system uses [EdDSA](https://tools.ietf.org/html/rfc8032) as it provides a robust and fast mechanism for hashing and providing security.
@@ -60,35 +34,3 @@ Lisk also offers the option of an additional layer of security. Using a  [specif
 
 ## Multisignature
 Lisk also supports multisignature accounts as another security system for users requiring even greater security. A multisignature account is an account that requires multiple keys to authorize a transaction. Any user can enable multisignature on their account by issuing a [special transaction](/documentation/lisk-protocol/transactions#multisignature-registration-transaction) specifying a group of n keys and the minimum number m of signatures required to authorize a transaction. Once this is done, it is mandatory that any transactions originating from that account must be signed by at least m out of the n keys for the transaction to be processed.
-
-----
-
-Opengraphtitle: Lisk Protocol - Security
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Security | Lisk Documentation
-
-----
-
-Whatsnext: asusual
-
-----
-
-Whatsnextheadline: 
-
-----
-
-Whatsnextpagelinktext: 
-
-----
-
-Whatsnextpagelink: 

--- a/technical-background/technical-background.md
+++ b/technical-background/technical-background.md
@@ -1,31 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-06-23
-
-----
-
-Metadescription: Lisk's technology stack has three major components: the JavaScript code, NodeJS as a compute engine and PostgreSQL as a storage and database solution.
-
-----
-
-Metakeywords: Technology Stack, javascript
-
-----
-
-Title: Technology Stack
-
-----
-
-Content: 
-
----
-
 ##Technology Stack
 
 Lisk software has three key components, the JavaScript code, NodeJS as a compute engine and PostgreSQL as a storage and database solution.
@@ -43,19 +15,3 @@ Lisk utilizes NodeJS as the backend computing engine for JavaScript code. NodeJS
 All blockchains preserve data in different ways, some choose to use SQLite while others use LevelDB. However, these solutions do not provide the same robust features of PostgreSQL.
 
 PostgreSQL is one of the oldest open source relational database systems in the world. With PostgreSQL, a user can store any form of information, such as binary files a music file. This makes PostgreSQL a perfect fit for the Lisk system and provides the necessary database engine to support blockchain applications. In addition to these features, the backup functionality and fault tolerance PostgreSQL offers is unmatched in the open source space.
-
-----
-
-Opengraphtitle: Lisk Protocol - Technology Stack
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Technology Stack | Lisk Documentation

--- a/transactions/transactions.md
+++ b/transactions/transactions.md
@@ -1,29 +1,3 @@
-Author: max
-
-----
-
-Created: 2018-01-25
-
-----
-
-Updated: 2018-08-06
-
-----
-
-Metadescription: This section of the Lisk Protocol reviews our blockchain transactions by type as well as transaction signing, balance transfer and more.
-
-----
-
-Metakeywords: blockchain transactions
-
-----
-
-Title: Transactions
-
-----
-
-Content: 
-
 # Lisk Transactions
 
 An overview of the transactions available on Lisk's network are shown below.  The different transaction types are explained in detail in the respective sections below. Some transaction types are currently disabled (as of 1.0 Core version) since the corresponding functionality is not implemented yet.
@@ -382,35 +356,3 @@ The following is a representation of the resulting JSON object that will be broa
 ```
 
 The final size of the transaction, with the signature, is 157 bytes, with a second signature it is 221 bytes.
-
-----
-
-Opengraphtitle: Lisk Protocol - Blockchain Transactions
-
-----
-
-Opengraphimage: 
-
-----
-
-Opengraphdescription: 
-
-----
-
-Htmltitle: Lisk Protocol - Blockchain Transactions | Lisk Documentation
-
-----
-
-Whatsnext: asusual
-
-----
-
-Whatsnextheadline: 
-
-----
-
-Whatsnextpagelinktext: 
-
-----
-
-Whatsnextpagelink: 


### PR DESCRIPTION
Closes #37 for lisk protocol