### PR TITLE
Update config pages - Closes #26

### DIFF
--- a/user-guide/administration/source/admin-source.md
+++ b/user-guide/administration/source/admin-source.md
@@ -46,11 +46,49 @@ View Realtime Logs (useful for troubleshooting issues)
 pm2 logs
 ```
 
-**NOTE:** The **port, address** and **config-path** can be overridden by providing the relevant command switch:
+## Command Line Options
 
-```shell
-pm2 start --name lisk app.js -- -p [port] -a [address] -c [config-path]
+There are plenty of options available that you can use to override configuration on runtime while starting the lisk.
+
 ```
+node app.js -p [port] -a [address] -c [config-path] -n [network]
+```
+or with pm2, e.g.:
+```
+pm2 start lisk -p [port] -a [address] -c [config-path] -n [network]
+```
+You can pass any of `devnet` (default), `alphanet`, `betanet`, `testnet` or `mainnet` for the network option.
+
+
+Each of these options can be appended on command line. There are also few `ENV` variables that can be utilized for this purpose.
+
+| Option                               | ENV Variable           | Config Option            | Description                                                                                                                                                                       |
+| ------------------------------------ | ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <pre nowrap>--network<br>-n</pre>    | LISK_NETWORK           |                          | Which configurations set to use, associated to lisk networks. Any of this option can be used `devnet`, `alphanet`, `betanet`, `testnet` and `mainnet`. Default value is `devnet`. |
+| <pre nowrap>--config<br> -c</pre>    | LISK_CONFIG_FILE       |                          | Path the custom configuration file, which will override values of `config/default/config.json`                                                                                    |
+| <pre nowrap>--port<br> -p</pre>      | LISK_WS_PORT           | wsPort                   | TCP port for P2P layer                                                                                                                                                            |
+| <pre nowrap>--http-port<br> -h</pre> | LISK_HTTP_PORT         | httpPort                 | TCP port for HTTP API                                                                                                                                                             |
+| <pre nowrap>--address<br> -a</pre>   | LISK_ADDRESS           | address                  | Listening host name or ip                                                                                                                                                         |
+| <pre nowrap>--log<br> -l</pre>       | LISK_FILE_LOG_LEVEL    | fileLogLevel             | Log level for file output                                                                                                                                                         |
+|                                      | LISK_CONSOLE_LOG_LEVEL | consoleLogLevel          | Log level for console output                                                                                                                                                      |
+|                                      | LISK_CACHE_ENABLED     | cacheEnabled             | Enable or disable cache. Must be set to true/false                                                                                                                                |
+| <pre nowrap>--database<br> -d</pre>  | LISK_DB_NAME           | db.database              | PostgreSQL database name to connect                                                                                                                                               |
+|                                      | LISK_DB_HOST           | db.host                  | PostgreSQL database host name                                                                                                                                                     |
+|                                      | LISK_DB_PORT           | db.port                  | PostgreSQL database port                                                                                                                                                          |
+|                                      | LISK_DB_USER           | db.user                  | PostgreSQL database username to connect                                                                                                                                           |
+|                                      | LISK_DB_PASSWORD       | db.password              | PostgreSQL database password to connect                                                                                                                                           |
+| <pre nowrap>--peers<br> -p</pre>     | LISK_PEERS             | peers.list               | Comma separated list of peers to connect in the format `192.168.99.100:5000,172.169.99.77:5000`                                                                                   |
+|                                      | LISK_API_PUBLIC        | api.access.public        | Enable or disable public access of http API. Must be set to true/false                                                                                                            |
+|                                      | LISK_API_WHITELIST     | api.access.whiteList     | Comma separated list of IPs to enable API access. Format `192.168.99.100,172.169.99.77`                                                                                           |
+|                                      | LISK_FORGING_DELEGATES | forging.delegates        | Comma separated list of delegates to load in the format _publicKey&#x7c;encryptedPassphrase,publicKey2&#x7c;encryptedPassphrase2_                                                 |
+|                                      | LISK_FORGING_WHITELIST | forging.access.whiteList | Comma separated list of IPs to enable access to forging endpoints. Format `192.168.99.100,172.169.99.77`                                                                          |
+| <pre nowrap>--snapshot<br> -s</pre>  |                        |                          | Number of round for which take the snapshot. If none specified it will use the highest round available.                                                                           |
+
+#### Note
+
+* All `ENV` variables restricted with operating system constraint of `ENV` variable maximum length.
+* Comma separated lists will replace the original config values. e.g. If you specify `LISK_PEERS`, original `peers.list` specific to network will be replaced completely.
+
 
 ## Rebuild source installation from a snapshot
 

--- a/user-guide/administration/source/admin-source.md
+++ b/user-guide/administration/source/admin-source.md
@@ -48,7 +48,7 @@ pm2 logs
 
 ## Command Line Options
 
-There are plenty of options available that you can use to override configuration on runtime while starting the lisk.
+There are plenty of options available that you can use to override configuration on runtime while starting Lisk Core.
 
 ```
 node app.js -p [port] -a [address] -c [config-path] -n [network]

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -46,8 +46,6 @@ The `config.json` file and a description of each parameter.
     "wsPort": 8001, // The port Lisk will listen to for WebSocket connections, e.g. P2P broadcasts
     "httpPort": 8000, // The port Lisk will listen to for HTTP connections, e.g. API calls
     "address": "0.0.0.0", // Specify the IPv4 Lisk will listen on (0.0.0.0 will listen to any IP)
-    "version": "1.0.0", // The version of Lisk
-    "minVersion": ">=1.0.0", // The minimum version Lisk will communicate with
     "fileLogLevel": "info", // Logging level for Lisk: info, error, debug, none
     "logFileName": "logs/lisk.log", // The path and name of the logfile
     "consoleLogLevel": "none", // The console logging level for app.js: info, error, debug, none

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -8,7 +8,7 @@
 - Default configuration file that is used as base is `config/default/config.json`
 - You can find network specific configurations under `config/<network>/config.json`, where `<network>` can be any of these values:
    - `devnet`
-   - `alpanet`
+   - `alphanet`
    - `betanet`
    - `testnet`
    - `mainnet`

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -12,12 +12,12 @@
    - `betanet`
    - `testnet`
    - `mainnet`
-- Configurations will be loaded in following order, lowest in the list have highest priority:
+- Configurations will be loaded in following order, each one will override the previous one:
    1. Default configuration file
    2. Network specific configuration file
    3. Custom configuration file (if specified by user)
-   4. Command line configurations, specified as command `flags` or `env` variables
-- For development purposes use `devnet` as network option, others network are specific to public lisk networks.
+   4. Command line configurations, specified as command-line flags or `ENV` variables.
+- For development purposes use `devnet` as a network option, other networks are specific to public Lisk networks.
 
 Info | Note 
 --- | --- 

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -1,6 +1,35 @@
 # Lisk Core Configuration
 
-The general config file for Lisk Core is located in the root directory of the Lisk Core repository.  We give you an overview for a greater understanding of the `config.json` file and a description of each parameter.
+## Structure
+
+- The **default** network is `devnet`. If you want to connect to another network specify the `network` when starting Lisk Core, as described in [Source Administration](../administration/source/admin-source.md#command-line-options)
+- The Lisk configuration is managed under different folder structures.
+- Root folder for all configuration is `./config/`.
+- Default configuration file that is used as base is `config/default/config.json`
+- You can find network specific configurations under `config/<network>/config.json`, where `<network>` can be any of these values:
+   - `devnet`
+   - `alpanet`
+   - `betanet`
+   - `testnet`
+   - `mainnet`
+- Configurations will be loaded in following order, lowest in the list have highest priority:
+   1. Default configuration file
+   2. Network specific configuration file
+   3. Custom configuration file (if specified by user)
+   4. Command line configurations, specified as command `flags` or `env` variables
+- For development purposes use `devnet` as network option, others network are specific to public lisk networks.
+
+Info | Note 
+--- | --- 
+![info note](../../info-icon.png "Info Note") | If none is specified, the default config value is `devnet`.
+
+Important | Note 
+--- | --- 
+![important note](../../important-icon.png "Important Note") | Don't override any value in above mentioned files if you need custom configuration.
+
+Info | Note 
+--- | --- 
+![info note](../../info-icon.png "Info Note") | To use a custom configuration: Create your own `json` file and pass it as [command line option](../administration/source/admin-source.md#command-line-options)
 
 For advanced configurations, please go directly to the sections listed below :
 
@@ -9,6 +38,8 @@ For advanced configurations, please go directly to the sections listed below :
   - [Enable/Disable Forging](#enable-disable-forging)
   - [Check Forging](#check-forging)
 - [SSL](#ssl)
+
+The `config.json` file and a description of each parameter.
 
 ```json
  {


### PR DESCRIPTION
Port Updates from Readme to docs:
- Command lines operations
- new config management

Remove `minVersion` and `version` from configuration description.

Closes #26 