### PR TITLE
Add references to 1.1 docs for testnet release - Closes #72

### DIFF
--- a/setup/install/docker/installation-docker.md
+++ b/setup/install/docker/installation-docker.md
@@ -2,7 +2,7 @@
 
 Info | Note
 ---- | ----
-![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 has been released to Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
 
 ## Run Lisk in Docker
 

--- a/setup/install/docker/installation-docker.md
+++ b/setup/install/docker/installation-docker.md
@@ -1,5 +1,9 @@
 # Lisk Core Docker Installation
 
+Info | Note
+---- | ----
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+
 ## Run Lisk in Docker
 
 We suggest using `docker-compose` to run Lisk and its dependencies in Docker containers:

--- a/setup/install/source/installation-source.md
+++ b/setup/install/source/installation-source.md
@@ -2,7 +2,7 @@
 
 Info | Note
 ---- | ----
-![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 has been released to Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
 
 This section details how to install Lisk Core from Source. When completed, you will have a functioning node on the Lisk Network. If you are looking to upgrade your current Lisk Core installation, please see [Upgrade from Source](/lisk-core/upgrade/source/upgrade-source.md).
 

--- a/setup/install/source/installation-source.md
+++ b/setup/install/source/installation-source.md
@@ -1,5 +1,9 @@
 # Lisk Core Source Installation
 
+Info | Note
+---- | ----
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+
 This section details how to install Lisk Core from Source. When completed, you will have a functioning node on the Lisk Network. If you are looking to upgrade your current Lisk Core installation, please see [Upgrade from Source](/lisk-core/upgrade/source/upgrade-source.md).
 
 ## Login as the Lisk user

--- a/setup/pre-install/source/preinstall-source.md
+++ b/setup/pre-install/source/preinstall-source.md
@@ -133,6 +133,10 @@ sudo npm install -g pm2
 
 ## 6. PostgreSQL (version 9.6)
 
+Info | Note
+---- | ----
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+
 ### Ubuntu
 
 Firstly, download and run the postgres install script:

--- a/setup/pre-install/source/preinstall-source.md
+++ b/setup/pre-install/source/preinstall-source.md
@@ -1,5 +1,9 @@
 # Lisk Core Source Pre-Install
 
+Info | Note
+---- | ----
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 has been released to Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+
 This document details the prerequisites to install Lisk Core 1.0.0 from a Source installation using tagged releases on Github.
 To complete the installation there are prerequisites that need to be fulfilled.  If you have already performed these, please proceed to the [Installation](/lisk-core/setup/install/source/install-source.md) page.
 
@@ -132,10 +136,6 @@ sudo npm install -g pm2
 ```
 
 ## 6. PostgreSQL (version 9.6)
-
-Info | Note
----- | ----
-![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
 
 ### Ubuntu
 

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -1,5 +1,9 @@
 # Lisk Core Configuration
 
+Info | Note
+---- | ----
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+
 The general config file for Lisk Core is located in the root directory of the Lisk Core repository.  We give you an overview for a greater understanding of the `config.json` file and a description of each parameter.
 
 For advanced configurations, please go directly to the sections listed below :

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -2,7 +2,7 @@
 
 Info | Note
 ---- | ----
-![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 is already released on Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
+![info note](../../../info-icon.png "Info Note") | Lisk Core 1.1 has been released to Testnet. If you wish to connect to Testnet, please refer to [Lisk Core 1.1.0 documentation](https://github.com/LiskHQ/lisk-docs/blob/core-1.1.0/introduction.md).
 
 The general config file for Lisk Core is located in the root directory of the Lisk Core repository.  We give you an overview for a greater understanding of the `config.json` file and a description of each parameter.
 


### PR DESCRIPTION
Add references to 1.1 docs for testnet release

Closes #72 