### PR TITLE
Update Lisk Source docs, to use src/index.js now

### DIFF
--- a/setup/source/source.md
+++ b/setup/source/source.md
@@ -277,7 +277,7 @@ npm ci
 To test that Lisk Core is built and configured correctly, issue the following command to connect to the network:
 
 ```bash
-node app.js --network [network]
+node src/index.js --network [network]
 ```
 
 Where `[network]` might be either `testnet` or `mainnet`.
@@ -288,7 +288,7 @@ Once the process is verified as running correctly, `CTRL+C` and start the proces
 This will fork the process into the background and automatically recover the process if it fails.
 
 ```bash
-npx pm2 start --name lisk app.js -- --network [network]
+npx pm2 start --name lisk src/index.js -- --network [network]
 ```
 Where `[network]` might be either `testnet` or `mainnet`.
 

--- a/setup/source/source.md
+++ b/setup/source/source.md
@@ -290,7 +290,7 @@ Alternatively, the user may define a custom `config.json`, like described in [Co
 Click here, to see a [list of available environment variables](../../user-guide/administration/source/source.md#command-line-options)
 
 If the process is running correctly, no errors are thrown in the logs.
-By default, errors will be logged in `logs/[network]/lisk.log` only. You can change the logging level in `config.json`.
+By default, errors will be logged in `logs/[network]/lisk.log`.
 Once the process is verified as running correctly, `CTRL+C` and start the process with `pm2`.
 This will fork the process into the background and automatically recover the process if it fails.
 

--- a/setup/source/source.md
+++ b/setup/source/source.md
@@ -277,20 +277,26 @@ npm ci
 To test that Lisk Core is built and configured correctly, issue the following command to connect to the network:
 
 ```bash
-node src/index.js --network [network]
+npm start # default: connect to Devnet
+LISK_NETWORK=[network] npm start # Use environment variables to overwrite config values (recommended)
+npm start -- --network [network]  # Use flags to overwrite config values
 ```
 
-Where `[network]` might be either `testnet` or `mainnet`.
+Where `[network]` might be either `devnet` (default), `alphanet`, `betanet`, `testnet` or `mainnet`.
+
+It is recommended to overwrite the config values with environment variables, if needed.
+Useable variables will always start with `LISK_` prefix.
+Click here, to see a [list of available environment variables](../../user-guide/administration/source/source.md#command-line-options)
 
 If the process is running correctly, no errors are thrown in the logs.
-By default, errors will be logged in `logs/lisk.log` only. You can change the logging level in `config.json`.
+By default, errors will be logged in `logs/[network]/lisk.log` only. You can change the logging level in `config.json`.
 Once the process is verified as running correctly, `CTRL+C` and start the process with `pm2`.
 This will fork the process into the background and automatically recover the process if it fails.
 
 ```bash
 npx pm2 start --name lisk src/index.js -- --network [network]
 ```
-Where `[network]` might be either `testnet` or `mainnet`.
+Where `[network]` might be either `devnet` (default), `alphanet`, `betanet`, `testnet` or `mainnet`.
 
 For details on how to manage or stop your Lisk node, please have a look in [Administration from Source](../../../user-guide/administration/source/admin-source.md).
 

--- a/setup/source/source.md
+++ b/setup/source/source.md
@@ -286,6 +286,7 @@ Where `[network]` might be either `devnet` (default), `alphanet`, `betanet`, `te
 
 It is recommended to overwrite the config values with environment variables, if needed.
 Useable variables will always start with `LISK_` prefix.
+Alternatively, the user may define a custom `config.json`, like described in [Configuarion of Lisk Core](../../user-guide/configuration/configuration.md)
 Click here, to see a [list of available environment variables](../../user-guide/administration/source/source.md#command-line-options)
 
 If the process is running correctly, no errors are thrown in the logs.

--- a/troubleshooting/troubleshooting.md
+++ b/troubleshooting/troubleshooting.md
@@ -6,7 +6,6 @@
 - **[Binary]** [A process is already listening on port 5432](#a-process-is-already-listening-on-port-5432-binary)
 - **[Source]** [error: role "lisk" does not exist](#role-lisk-does-not-exist-source)
 - **[Source]** [Nothing shown in console after starting Lisk Core](#nothing-shown-in-console-after-starting-lisk-core-source)
-- **[Source]** ['npm install' fails with error 'Failed at the sodium@2.0.1 preinstall script.'](#npm-install-fails-with-error-source)
 
 ### Administration
 - [Enable forging: delegate not found](#enable-forging-delegate-not-found)
@@ -81,34 +80,12 @@ Edit [`config.json`](../user-guide/configuration/configuration.md) and replace t
 ### Nothing shown in console after starting Lisk Core (Source)
 
 #### Problem: 
-After installing from Source and starting Lisk Core with `node src/index.js`, no are logs visible in console.
+After installing from Source and starting Lisk Core with `npm start`, no are logs visible in console.
 This is in fact an expected behaviour, as the default console logging value in the config is `none`, which means no logs are shown in the console after starting the process.
 
 #### Solution: 
 To verify, that your installation works as expected, you can change the`consoleLogLevel` to `error`, `info` or `debug`.
 Alternatively, you can check the log files located in `logs/`, which are on `info` logging level by default.
-
-### npm install fails with error (Source)
-
-> This issue should not be present anymore since Lisk Core `v1.2`
-
-#### Problem:
-`npm install` fails with error `Failed at the sodium@2.0.1 preinstall script.`
-When trying to install the necessary node modules for Lisk Core, the install script fails while trying to build sodium.
-This happens for newer versions of npm, which are not supported by core 1.0.0, yet.
-#### Solution:
-Install npm version 3.10.10.
-Check if you have the correct Node version installed by running `node -v`
-If the version is not ^6.14.1, first install the supported Node version.
-```bash
-nvm install 6.14.1
-```
-With the right node version, you can proceed to install the right `npm` verison:
-```bash
-node -v
-v6.14.1
-npm install npm@3.10.10
-```
 
 ## Administration
 

--- a/troubleshooting/troubleshooting.md
+++ b/troubleshooting/troubleshooting.md
@@ -81,7 +81,7 @@ Edit [`config.json`](../user-guide/configuration/configuration.md) and replace t
 ### Nothing shown in console after starting Lisk Core (Source)
 
 #### Problem: 
-After installing from Source and starting Lisk Core with `node app.js`, no are logs visible in console.
+After installing from Source and starting Lisk Core with `node src/index.js`, no are logs visible in console.
 This is in fact an expected behaviour, as the default console logging value in the config is `none`, which means no logs are shown in the console after starting the process.
 
 #### Solution: 

--- a/user-guide/administration/source/admin-source.md
+++ b/user-guide/administration/source/admin-source.md
@@ -67,12 +67,14 @@ npx pm2 logs
 
 There are plenty of options available that you can use to override configuration on runtime while starting Lisk Core.
 
+How to overwrite config options from the Command line:
 ```bash
-node src/index -p [port] -a [address] -c [config-path] -n [network]
+LISK_NETWORK=[network] LISK_CONFIG_FILE=[config-path] LISK_ADDRESS=[address] LISK_WS_PORT=[port] npm start # Pass options as environment variables (recommended)
+npm start -p [port] -a [address] -c [config-path] -n [network] # Pass options as flags
 ```
 or with pm2, e.g.:
 ```bash
-npx pm2 start lisk -p [port] -a [address] -c [config-path] -n [network]
+LISK_NETWORK=[network] LISK_CONFIG_FILE=[config-path] LISK_ADDRESS=[address] LISK_WS_PORT=[port] npx pm2 start lisk
 ```
 You can pass any of `devnet` (default), `alphanet`, `betanet`, `testnet` or `mainnet` for the network option.
 

--- a/user-guide/administration/source/admin-source.md
+++ b/user-guide/administration/source/admin-source.md
@@ -67,7 +67,7 @@ npx pm2 logs
 
 There are plenty of options available that you can use to override configuration on runtime while starting Lisk Core.
 
-How to overwrite config options from the Command line:
+How to overwrite config options from the Command Line:
 ```bash
 LISK_NETWORK=[network] LISK_CONFIG_FILE=[config-path] LISK_ADDRESS=[address] LISK_WS_PORT=[port] npm start # Pass options as environment variables (recommended)
 npm start -p [port] -a [address] -c [config-path] -n [network] # Pass options as flags

--- a/user-guide/administration/source/admin-source.md
+++ b/user-guide/administration/source/admin-source.md
@@ -53,7 +53,7 @@ npx pm2 delete lisk
 ### Add
 In case you haven't done this during the Installation process, add your Lisk Core process to pm2 under the name `lisk`.
 ```bash
-npx pm2 start --name lisk app.js -- --network [network]
+npx pm2 start --name lisk src/index.js -- --network [network]
 ```
 Where `[network]` might be either `testnet` or `mainnet`.
 
@@ -68,7 +68,7 @@ npx pm2 logs
 There are plenty of options available that you can use to override configuration on runtime while starting Lisk Core.
 
 ```bash
-node app.js -p [port] -a [address] -c [config-path] -n [network]
+node src/index -p [port] -a [address] -c [config-path] -n [network]
 ```
 or with pm2, e.g.:
 ```bash

--- a/user-guide/configuration/configuration.md
+++ b/user-guide/configuration/configuration.md
@@ -39,7 +39,7 @@ The `config.json` file and a description of each parameter.
     "address": "0.0.0.0", // Specify the IPv4 Lisk will listen on (0.0.0.0 will listen to any IP)
     "fileLogLevel": "info", // Logging level for Lisk: info, error, debug, none
     "logFileName": "logs/lisk.log", // The path and name of the logfile
-    "consoleLogLevel": "none", // The console logging level for app.js: info, error, debug, none
+    "consoleLogLevel": "none", // The console logging level for lisk: info, error, debug, none
     "trustProxy": false, // If true, client IP addresses are understood as the left-most entry in the X-Forwarded-* header
     "topAccounts": false, // Deprecated, will be removed in future releases
     "cacheEnabled": false, // If true, enables cache


### PR DESCRIPTION
The docs were still referring to the outdated `app.js` file.

Updated docs to use src/index.js now.

Closes #179 