### PR TITLE
Fix example delegate registration transaction, closes #298

### DIFF
--- a/transactions.md
+++ b/transactions.md
@@ -137,7 +137,6 @@ The JSON object that will be broadcast to the network follows the format below:
     "asset": {
         "delegate": {
             "username": The chosen username
-            "publicKey": The public key of the delegate (the sender)
         }
     }
     ...


### PR DESCRIPTION
Removed line containing `publicKey` from the example JSON object.
Note that this fix should be implemented for all protocol documentations since protocol version 1.0.

Closes #298 