### PR TITLE
Add temppath parameter

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -46,6 +46,7 @@ To change them, override the specific default values with custom ones, when init
         version: "", // version of the application (required)
         minVersion: "", // minimal compatible version (required)
         protocolVersion: "", // protocol Version of the application (required)
+	tempPath: "/tmp/lisk", // root path for storing temporary pid and socket file.
         ipc: { enabled: false}, // If true, allows modules to communicate over IPCs (inter-process-channels).
         genesisConfig: { // Network specific constants
             EPOCH_TIME: new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0)).toISOString(), // Timestamp indicating the initial network start (`Date.toISOString()`).


### PR DESCRIPTION
The `tempPath` parameter is used for defining the location for storing the temporary pid and socket files.
This property has been introduced because of the restricted length for unix domain sockets (104 on MacOs and 108 on Linux) so users can change the location to a shorter path if needed. (Introduced in 2.1)

Related PR: https://github.com/LiskHQ/lisk-sdk/pull/3957