### PR TITLE
#324 - use process.exit(0)

### DIFF
--- a/start/tutorials/cashback.md
+++ b/start/tutorials/cashback.md
@@ -624,7 +624,7 @@ app
     .then(() => app.logger.info('App started...'))
     .catch(error => {
         console.error('Faced error in application', error);
-        process.exit(1);
+        process.exit(0);
     });
 ```
 


### PR DESCRIPTION
process.exit(1) should be used for errors rather than expected behaviour
#324 