### PR TITLE
Update link to PostgreSQL documentation

### DIFF
--- a/modules/ROOT/pages/administration/binary.adoc
+++ b/modules/ROOT/pages/administration/binary.adoc
@@ -92,7 +92,7 @@ For more information, how to manage your Node with PM2, go to the xref:administr
 === psql
 
 The interactive terminal for postgreSQL comes bundled with the Lisk Core Binary distribution and will be available after <<_update_path_environment_variable, Updating the PATH environment>>.
-For more information about available commands, see the official https://www.postgresql.org/docs/9.6/static/app-psql.html[PostgreSQL Documentation]
+For more information about available commands, see the official https://www.postgresql.org/docs/10/static/app-psql.html[PostgreSQL Documentation]
 
 == Utility scripts
 


### PR DESCRIPTION
Lisk Core uses version 10 of psql. Updated link should point to https://www.postgresql.org/docs/10/static/app-psql.html .