### PR TITLE
correct minor misspelling of "form"

### DIFF
--- a/modules/ROOT/pages/administration/binary.adoc
+++ b/modules/ROOT/pages/administration/binary.adoc
@@ -181,7 +181,7 @@ bash lisk.sh rebuild
 bash lisk.sh rebuild -f blockchain.db.gz
 ----
 
-==== Rebuild form a remote hosts snapshot
+==== Rebuild from a remote hosts snapshot
 
 If the file is named `blockchain.db.gz`, use this command
 


### PR DESCRIPTION
Change: "Rebuild form a remote hosts snapshot"
To: "Rebuild from a remote hosts snapshot"