### PR TITLE
Add a git checkout master step to the Docker docs

### DIFF
--- a/modules/ROOT/pages/setup/docker.adoc
+++ b/modules/ROOT/pages/setup/docker.adoc
@@ -65,11 +65,13 @@ Clone the https://github.com/LiskHQ/lisk-core[Lisk Core Repository].
 sudo -u lisk -i                                    <1>
 git clone https://github.com/LiskHQ/lisk-core.git  <2>
 cd lisk-core/docker                                <3>
+git checkout master                                <4>
 ----
 
 <1> switch to lisk user
 <2> clone the repository
 <3> navigate into docker directory
+<4> checkout master branch for last stable version of Lisk Core
 
 It contains a directory `docker` with the following files:
 


### PR DESCRIPTION
If you follow the docker docs, it will automatically checkout on `development` branch, which is not the latest stable version of Lisk Core and it will not coldstart.

I'd suggest to checkout to `master` branch in order to make sure that the user is on the latests stable version.