### PR TITLE
Fix issues in intro/pre-requisites guides in SDK docs - closes #536

### DIFF
--- a/modules/ROOT/pages/guides/broadcast.adoc
+++ b/modules/ROOT/pages/guides/broadcast.adoc
@@ -87,7 +87,7 @@ console.log(tx.stringify());
 Custom transaction::
 +
 --
-The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello world tutorials] is used as an example here.
+The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello World tutorials] is used as an example here.
 
 .How to create a custom tx object with Lisk Elements
 [source,js]
@@ -182,7 +182,7 @@ console.log(tx.stringify());
 Custom transaction::
 +
 --
-The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello world tutorials] is used as an example here.
+The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello World tutorials] is used as an example here.
 
 .How to sign a custom tx object with Lisk Elements
 [source,js]
@@ -302,7 +302,7 @@ Replace `http://localhost:4000` with the url of the node, to which you want to b
 Custom Transaction::
 +
 --
-The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello world tutorials] is used as an example here.
+The `HelloTransaction` from the xref:{url_tutorials_hello}[Hello World tutorials] is used as an example here.
 
 .How to create, sign and post a transaction
 [source,js]

--- a/modules/ROOT/pages/guides/configuration.adoc
+++ b/modules/ROOT/pages/guides/configuration.adoc
@@ -19,7 +19,7 @@ To change the configuration, pass a config object as parameter when creating a n
 During development of a blockchain application it is recommended to import and use the `configDevnet` object from the Lisk SDK.
 Together with `genesisBlockDevnet`, which defines the <<genesis_block, genesis block>>, it sets up a local development environment with 101 forging genesis delegates.
 
-.index.js of the Hello world app
+.index.js of the Hello World app
 [source,js]
 ----
 const { Application, genesisBlockDevnet, configDevnet} = require('lisk-sdk'); <1>

--- a/modules/ROOT/pages/guides/customize.adoc
+++ b/modules/ROOT/pages/guides/customize.adoc
@@ -79,7 +79,7 @@ class HelloTransaction extends BaseTransaction {
 	}
 
     /**
-    * applyAsset is where the custom logic of the Hello world app is implemented.
+    * applyAsset is where the custom logic of the Hello World app is implemented.
     * applyAsset() and undoAsset() uses the information about the sender's account from the `store`.
     * Here it is possible to store additional information regarding the accounts using the `asset` field. The content property of "hello" transaction's asset is saved into the "hello" property of the account's asset.
     */

--- a/modules/ROOT/pages/guides/frontend.adoc
+++ b/modules/ROOT/pages/guides/frontend.adoc
@@ -33,9 +33,9 @@ NOTE: This guide builds a frontend based on the {url_react_app}[Create React App
 
 == Create project structure
 
-TIP: See the full code example of {url_github_hello}[Hello world in GitHub].
+TIP: See the full code example of {url_github_hello}[Hello World in GitHub].
 
-.Structure of the Hello world app
+.Structure of the Hello World app
 ....
 $ tree -I 'node_modules|client/node_modules|react-client/node_modules'
 .
@@ -144,17 +144,17 @@ npm start
 
 This will open the client app in the browser, under `http://localhost:3000`.
 
-At this point, it should now be possible to see a basic frontend for the Hello world application, that allows users to perform the following tasks:
+At this point, it should now be possible to see a basic frontend for the Hello World application, that allows users to perform the following tasks:
 
-* create new accounts
-* send tokens to accounts
-* get tokens from a faucet
-* send `Hello` transactions
-* explore all blocks
-* explore all transactions and `Hello` transactions
-* explore all `Hello` transactions
-* explore all accounts and `Hello` accounts
-* explore all `Hello` accounts
+* Create new accounts.
+* Send tokens to accounts.
+* Get tokens from a faucet.
+* Send `Hello` transactions.
+* Explore all blocks.
+* Explore all transactions and `Hello` transactions.
+* Explore all `Hello` transactions.
+* Explore all accounts and `Hello` accounts.
+* Explore all `Hello` accounts.
 
 TIP: Use this client as a template or reference for your own client applications, and adjust it to suit your requirements.
 

--- a/modules/ROOT/pages/guides/index.adoc
+++ b/modules/ROOT/pages/guides/index.adoc
@@ -26,17 +26,17 @@ The most important parts of building a blockchain application are described belo
 . In the xref:{url_frontend}[connect a frontend guide], how to develop a {url_react}[React] frontend for a blockchain application is explained.
 . Finally, the xref:{url_launch}[launch the app guide] describes the steps needed to move from a local devnet to a public blockchain network.
 
-== The Hello world app
+== The Hello World app
 
-As an example, the guides use the {url_github_hello}[Hello world] app, which contains a very basic blockchain application with one custom transaction type and a simple frontend.
+As an example, the guides use the {url_github_hello}[Hello World] app, which contains a very basic blockchain application with one custom transaction type and a simple frontend.
 
 This basic example describes a minimal set of code which is required to implement a blockchain application.
 
-If you wish to follow the guides on a 1-to-1 basis, it is recommend to set up the 'Hello world' app as described below.
+If you wish to follow the guides on a 1-to-1 basis, it is recommend to set up the 'Hello World' app as described below.
 
 Alternatively it is possible to start directly with your own use case, or a xref:{url_tutorials}[tutorial], and then refer back to the guides for further detailed information on certain specific topics, as and when required.
 
-To set up the Hello world app, first install the xref:{url_setup}[prerequisites], then clone the repository and navigate into it as shown below:
+To set up the Hello World app, first install the xref:{url_setup}[prerequisites], then clone the repository and navigate into it as shown below:
 
 .In the terminal
 [source,bash]

--- a/modules/ROOT/pages/guides/index.adoc
+++ b/modules/ROOT/pages/guides/index.adoc
@@ -68,4 +68,4 @@ The delegates will then add a new block to the blockchain, which will also be vi
 
 image::run_a_blockchain_10_secs.gif[Logs of a node]
 
-All remaining topics of the Hello Word application are explained further in the dedicated Lisk SDK guides.
+All remaining topics of the Hello World application are explained further in the dedicated Lisk SDK guides.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Introduction
 Mona Bärenfänger <mona@lightcurve.io>
-:description: The Lisk SDK introduction describes it's components, architecture, and usage.
+:description: The Lisk SDK introduction describes its components, architecture, and usage.
 :toc: preamble
 :imagesdir: ../assets/images
 :v_core: 3.0.0
@@ -26,12 +26,12 @@ image:banner_sdk.png[Logo]
 
 
 Please read this carefully.
-The current version of the SDK is the alpha release stage.
+The Lisk SDK is currently in the the alpha release stage.
 The Lisk SDK has been released in its current form in order to improve the development experience through community feedback and contributions.
 
 It is definitely NOT recommended to use the alpha release of the Lisk SDK for any production-based blockchain applications, i.e. a blockchain operating on a live mainnet.
 
-Over the course of the SDK’s alpha phase there will be significant changes in the Lisk protocol and implementation, which will eventually bring the accessibility and reliability to a level which is feasible for production-based blockchain applications.
+Over the course of the Lisk SDK’s alpha phase there will be significant changes in the Lisk protocol and implementation, which will eventually bring the accessibility and reliability to a level which is feasible for production-based blockchain applications.
 
 At this time it is only recommended that the alpha version of the Lisk SDK is used for proof-of-concept blockchain applications, i.e. a blockchain operating on a stand-alone network.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -131,13 +131,13 @@ To get started with the Lisk SDK and the development of a blockchain application
 
 === How-To Guides
 
-The xref:{url_guides}[guides] section offers dedicated 'how-to guides' which cover all of the relevant topics required to build a blockchain application with the Lisk SDK.
+The xref:{url_guides}[Guides] section offers dedicated 'how-to guides' which cover all of the relevant topics required to build a blockchain application with the Lisk SDK.
 
 The guides are arranged in chronological order, however they can also be read separately as well as being used as a source to locate certain commands or code snippets.
 
 === Tutorials
 
-The xref:{url_tutorials}[tutorials] explain in detail how to build a specific blockchain application.
+The xref:{url_tutorials}[Tutorials] explain in detail how to build a specific blockchain application.
 All examples provided in the tutorials describe how to implement simple, but valid industry use cases.
 
 The tutorials overview page provides an informative overview about all existing tutorials, including the estimated time and the skill level required to complete each specific tutorial.

--- a/modules/ROOT/pages/setup.adoc
+++ b/modules/ROOT/pages/setup.adoc
@@ -128,4 +128,4 @@ npm install lisk-sdk
 
 After successful completion of all the above steps, the Lisk SDK and and all required dependencies are installed.
 
-You may now head to the xref:{url_guides}[Guides] section to learn how to build a blockchain application with the SDK, or directly head to the xref:{url_tutorials}[tutorials] to learn how to build proof of concept blockchain applications for real industry use cases.
+The next step now is to head to the xref:{url_guides}[Guides] section to learn how to build a blockchain application with the Lisk SDK, or directly head to the xref:{url_tutorials}[Tutorials] to learn how to build proof of concept blockchain applications for real industry use cases.


### PR DESCRIPTION
closes #536 

Introduction: The current version of the SDK is the alpha release stage. should be 'The Lisk SDK is currently in alpha stage'. and always call it Lisk SDK, not only SDK.
Prerequisites: Ubuntu/macOS, there should be an order. And either Linux or Ubuntu.
Guides: There is a typo: Hello World. Should be Hello World and not Hello world.

Parent issue #535 