### PR TITLE
Fix image alignment

### DIFF
--- a/modules/ROOT/pages/accounts.adoc
+++ b/modules/ROOT/pages/accounts.adoc
@@ -23,7 +23,7 @@ Verification of the validity of a transaction requires the state of the referenc
 
 This section lists the properties stored in a Lisk account.
 
-image:unif_diagrams/Account.png[accountJSON]
+image::unif_diagrams/Account.png[accountJSON]
 
 // image:InfographicsV1/Infographic1.png[accountJSON2]
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -45,7 +45,7 @@ Delegates agree on blocks using the [#index-lisk_bft-1]#*Lisk-BFT*# consensus al
 
 The following diagram depicts the main characteristics of the Lisk protocol.
 
-image:unif_diagrams/intro.png[introDiagram]
+image::unif_diagrams/intro.png[introDiagram]
 
 This documentation is structured as follows:
 

--- a/modules/ROOT/pages/transactions.adoc
+++ b/modules/ROOT/pages/transactions.adoc
@@ -35,7 +35,7 @@ In the table below, a summary of these transaction types and the purpose each of
 
 == Transaction properties
 
-image:unif_diagrams/BaseTransaction.png[TxDiagram,width=339,height=310]
+image::unif_diagrams/BaseTransaction.png[TxDiagram,width=339,height=310]
 
 Every transaction object in the Lisk protocol, regardless of the type, has a common set of properties. These properties are shown in the subsection below.
 
@@ -105,7 +105,7 @@ The key points and useful information for each of these transactions are comment
 [[transfer]]
 === Balance transfer
 
-image:unif_diagrams/BalanceTransferAsset.png[BalanceTDiagram,340,211]
+image::unif_diagrams/BalanceTransferAsset.png[BalanceTDiagram,340,211]
 
 This transaction type transfers the amount of tokens specified in the `amount` property from the xref:{url_accounts}[account] corresponding to the `senderPublicKey`, i.e. the sender account, to the account specified in `recipientAddress`.
 This transaction offers the possibility to send a message in the optional property `data`.
@@ -120,7 +120,7 @@ This transaction registers the sender account as a xref:{url_consensus_voting_an
 [[vote]]
 === Vote
 
-image:unif_diagrams/VoteAsset.png[VoteDiagram,736,192]
+image::unif_diagrams/VoteAsset.png[VoteDiagram,736,192]
 
 This transaction submits the votes specified in `votes` from the sender account.
 This is accomplished by specifying the Lisk xref:{url_accounts_address}[address] of the voted delegate in `delegateAddress` together with the amount of support given to this delegate in `amount`.
@@ -131,7 +131,7 @@ The maximum number of votes that can be cast in a single transaction is 20 and `
 [[unlock]]
 === Unlock vote
 
-image:unif_diagrams/UnlockVoteAsset.png[UnlockVoteDiagram,765,202]
+image::unif_diagrams/UnlockVoteAsset.png[UnlockVoteDiagram,765,202]
 
 This transaction [#index-unlocked-2]#*unlocks*# the tokens specified in `amount` that were previously unvoted for the delegate specified by `delegateAddress` by a vote transaction at the height given in the property `unvoteHeight`.
 This transaction is only valid if it is issued after the unlocking period has been completed since `unvoteHeight`.
@@ -141,7 +141,7 @@ For self-votes, i.e. if the `delegateAddress` property of the transaction is equ
 [[multisignature]]
 === Multisignature registration
 
-image:unif_diagrams/MultisigRegAsset.png[MultisigDiagram,375,204]
+image::unif_diagrams/MultisigRegAsset.png[MultisigDiagram,375,204]
 
 This transaction registers the sender account as a multisignature account.
 The set of [#index-mandatory-2]#*mandatory*# keys needs to be specified in `mandatoryKeys` whereas the set of [#index-optional-2]#*optional*# keys have to be specified in `optionalKeys`.


### PR DESCRIPTION
Fix the alignment of every image so all of them are centered using the syntax `image::` (double colon)