### PR TITLE
Remove all links to migration page and update nav page in Core docs 2.1.5 - closes #603 

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -20,7 +20,6 @@
 ** xref:update/commander.adoc[Commander]
 ** xref:update/docker.adoc[Docker]
 ** xref:update/source.adoc[Source]
-* xref:migration.adoc[Migration]
 * xref:monitoring.adoc[Monitoring]
 * Reference
 ** xref:reference/api.adoc[API (Testnet)]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -23,7 +23,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_config: management/configuration.adoc
 :url_config_forging: management/forging.adoc
 :url_interact_with_network: interact-with-network.adoc
-:url_migration: migration.adoc
 :url_setup_binary: setup/binary.adoc
 :url_setup_commander: setup/commander.adoc
 :url_setup_docker: setup/docker.adoc
@@ -80,7 +79,7 @@ Node operators are required to set up Lisk Core on a server, and then connect it
 There are over 600 nodes around the world that are maintained by individuals, and these nodes communicate with the network.
 For example, by broadcasting and receiving blocks or transactions from their peers.
 In addition, Lisk nodes are also required to forge/add new blocks to the blockchain.
-It is possible to view the live network statistics by accessing the following URL: {url_explorer}[Lisk’s Blockchain Explorer].
+It is possible to view the live network statistics by accessing the following URL: {url_explorer}[Lisk’s Blockchain Explorer^].
 
 === Who should operate a node?
 
@@ -242,18 +241,3 @@ The first digit, `H`, depends on the number of hard forks, and is incremented wi
 NOTE: The initial protocol version 1.0 is defined as the version that was implemented by Lisk Core v1.0.0.
 
 For example, the _protocol version_ is used in P2P communication between Lisk Core nodes, in order to determine if the nodes have compatible versions of the Lisk protocol implemented.
-
-[[upgrade_vs_migration]]
-== Update vs Migration
-
-When to update, and when to migrate Lisk Core?
-
-Every time that a new Lisk Core software update is performed, this introduces a *hard fork* in the network, hence it is necessary to xref:{url_migration}[migrate] your existing Lisk Core version.
-
-In all other cases the normal *update* process can be performed, according to the distribution being used.
-Please see the following updating processes listed below:
-
-* xref:{url_upgrade_binary}[Update Binary]
-* xref:{url_upgrade_commander}[Update Commander]
-* xref:{url_upgrade_docker}[Update Docker]
-* xref:{url_upgrade_source}[Update Lisk Source]

--- a/modules/ROOT/pages/management/docker.adoc
+++ b/modules/ROOT/pages/management/docker.adoc
@@ -10,6 +10,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_docker_compose_compose: https://docs.docker.com/compose/compose-file/#environment
 :url_docker_compose_exec: https://docs.docker.com/compose/reference/exec/
 :url_lisk_snapshots: http://snapshots.lisk.io
+:url_config: management/configuration.adoc
 :url_config_cl: reference/config.adoc#clo
 :url_setup_docker_install: setup/docker.adoc#install
 

--- a/modules/ROOT/pages/management/docker.adoc
+++ b/modules/ROOT/pages/management/docker.adoc
@@ -10,7 +10,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_docker_compose_compose: https://docs.docker.com/compose/compose-file/#environment
 :url_docker_compose_exec: https://docs.docker.com/compose/reference/exec/
 :url_lisk_snapshots: http://snapshots.lisk.io
-:url_config: management/configuration.adoc
+:url_config_cl: reference/config.adoc#clo
 :url_setup_docker_install: setup/docker.adoc#install
 
 This section details how to work with a Docker-based Lisk Core installation, and covers the available basic commands which can be used to manage your Docker-based Lisk node.


### PR DESCRIPTION
closes #603 