### PR TITLE
Update title in config page in Core docs 2.1.6 - closes #605  

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -10,7 +10,7 @@
 ** xref:management/commander.adoc[Commander commands]
 ** xref:management/docker.adoc[Docker commands]
 ** xref:management/source.adoc[Source commands]
-** xref:management/configuration.adoc[Config file handling]
+** xref:management/configuration.adoc[Handle config files]
 ** xref:management/api-access.adoc[Control API access]
 ** xref:management/forging.adoc[Enable forging]
 ** xref:management/logs.adoc[Activate logging]

--- a/modules/ROOT/pages/management/configuration.adoc
+++ b/modules/ROOT/pages/management/configuration.adoc
@@ -1,4 +1,4 @@
-= Config file handling
+= Handle config files
 Mona Bärenfänger <mona@lightcurve.io>
 :description: Explains how to configure Lisk Core.
 :toc:
@@ -9,6 +9,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_config_structure: reference/config.adoc#structure
 :url_sdk_framework: {v_sdk}@lisk-sdk::reference/lisk-framework/index.adoc
 :url_management_docker_config: management/docker.adoc#config
+
 
 [IMPORTANT]
 ====
@@ -21,7 +22,7 @@ Please go to the xref:{url_management_docker_config}[Docker commands] page to fi
 
 The root folder for all configurations is `config/`.
 The *default* network is `devnet`.
-To connect to another network, specify the `network` when starting the Lisk Core, as described in the xref:{url_config_clo}[configuration reference].
+To connect to another network, specify the `network` when starting the Lisk Core, as described in the xref:{url_config_clo}[Configuration reference].
 The *network specific configurations* can be found under `config/<network>/config.json`, whereby `<network>` can be any of these values listed below:
 
 * `devnet`
@@ -94,9 +95,9 @@ LISK_CONFIG_FILE=<CONFIG_PATH> pm2 start lisk <2>
 Configurations will be loaded in the following order listed below.
 Each configuration will override the previous one:
 
-. Default configuration values of modules and components of the xref:{url_sdk_framework}[Lisk Framework]
-. <<network_specific_config, Network specific configuration file>>
-. A xref:{url_config_clo}[custom configuration file] (if specified by the user)
+. Default configuration values of modules and components of the xref:{url_sdk_framework}[Lisk Framework].
+. <<network_specific_config, Network specific configuration file>>.
+. A xref:{url_config_clo}[custom configuration file], (if specified by the user).
 . xref:{url_config_clo}[Command line configurations], specified as command-line flags or `ENV` variables.
 
 For development purposes, use `devnet` as the network option.


### PR DESCRIPTION
closes #605 

Change to Handle config files