### PR TITLE
Add tutorials/hello-world.adoc to /tutorials index

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 ** xref:guides/forging.adoc[Enable forging]
 ** xref:guides/launch.adoc[Launch a blockchain application]
 * xref:tutorials/index.adoc[Tutorials]
+** xref:tutorials/hello-world.adoc[Hello World]
 ** xref:tutorials/transport.adoc[Supply Chain]
 *** xref:tutorials/transport0.adoc[Part 0: Installation & setup]
 *** xref:tutorials/transport1.adoc[Part 1: Track a packet on the blockchain]

--- a/modules/ROOT/pages/tutorials/index.adoc
+++ b/modules/ROOT/pages/tutorials/index.adoc
@@ -17,6 +17,18 @@ To become both familiar and fully conversant with the Lisk SDK, a step-by-step w
 |Complexity
 |Content
 
+| xref:tutorials/hello-world.adoc[Hello World]
+|~1 h
+|Beginner
+a|
+Learn how to: 
+
+* ...setup a simple blockchain application
+* ...install the `lisk-sdk` and the SDK preinstall prepartion
+* ...create a custom transaction type
+* ...register a new transaction type
+* ...interact with the network from the client-side.
+* ...override specific config values.
 
 | xref:tutorials/transport.adoc[Supply Chain]
 |~3 h


### PR DESCRIPTION
On the [tutorials page](https://lisk.io/documentation/lisk-sdk/tutorials/index.html), this adds the [Hello World](https://lisk.io/documentation/lisk-sdk/tutorials/hello-world.html) example to the table; allowing new SDK users to see an easier example.

Add
  - link to hello-world documentation, estimated time required, complexity, and content to the