### PR TITLE
Wrong NVM version in setup page in SDK docs 3.0.2 - Closes 638

### DIFF
--- a/modules/ROOT/partials/install-node.adoc
+++ b/modules/ROOT/partials/install-node.adoc
@@ -40,7 +40,7 @@ Alternatively, instead of using the NVM or other package managers, the node pack
 
 [source,bash]
 ----
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_12.15.0 | sudo -E bash -
 sudo apt-get install -y nodejs
 ----
 

--- a/modules/ROOT/partials/install-node.adoc
+++ b/modules/ROOT/partials/install-node.adoc
@@ -40,7 +40,7 @@ Alternatively, instead of using the NVM or other package managers, the node pack
 
 [source,bash]
 ----
-curl -sL https://deb.nodesource.com/setup_12.15.0 | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ----
 


### PR DESCRIPTION


Closes issue #638 