### PR TITLE
Restructure mgmt guides from Core docs to SDK docs - closes #731

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -10,10 +10,7 @@
 ** xref:management/docker.adoc[Docker image commands]
 ** xref:management/source.adoc[Source code commands]
 ** xref:management/configuration.adoc[Handle config files]
-** xref:management/api-access.adoc[Control API access]
 ** xref:management/forging.adoc[Enable forging]
-** xref:management/logs.adoc[Activate logging]
-** xref:management/ssl.adoc[Enable SSL]
 * Update
 ** xref:update/application.adoc[Application]
 ** xref:update/commander.adoc[Commander application]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -7,7 +7,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-no-previous: true
 :page-next: /lisk-core/interact-with-the-api.html
 :page-next-title: Interact with the API
-
 :v_sdk: master
 
 :url_explorer: https://explorer.lisk.io

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -104,7 +104,7 @@ There are several advantages why one would wish to set up a node, and these are 
 This is especially important when running an exchange and implementing LSK tokens.
 - To acquire full control in order to xref:{url_config}[configure] the node to your specific requirements.
 - To create your own xref:{url_snapshots}[snapshots][[Snapshots]] of the blockchain.
-- To have the option to xref:{url_config_forging}[forge] new blocks, (assuming you are an active delegate)
+- To have the option to xref:{url_config_forging}[forge] new blocks, (assuming you are an active delegate).
 
 NOTE: To learn how to set up a node, please go to the xref:{url_getting_started}[setup overview] page.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,9 +4,13 @@ Mona Bärenfänger <mona@lightcurve.io>
 :imagesdir: ./../assets/images
 :toc:
 :page-aliases: troubleshooting.adoc
-:page-no-previous: true
+
 :page-next: /lisk-core/interact-with-the-api.html
 :page-next-title: Interact with the API
+:page-no-previous: true
+:v_sdk: master
+:page-aliases: monitoring.adoc
+:page-aliases: migration.adoc
 
 :url_explorer: https://explorer.lisk.io
 :url_explorer_testnet: https://testnet-explorer.lisk.io
@@ -21,8 +25,11 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_swagger: https://swagger.io
 :url_admin_binary_snapshot: management/application.adoc#create_snapshot
 :url_config: management/configuration.adoc
+:url_config_api: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc
 :url_config_forging: management/forging.adoc
 :url_interact_with_network: interact-with-the-api.adoc
+:url_protocol_forging: master@lisk-protocol::blocks.adoc#forgers
+:url_setup: setup/index.adoc#distributions
 :url_setup_binary: setup/application.adoc
 :url_setup_commander: setup/commander.adoc
 :url_setup_docker: setup/docker.adoc
@@ -32,7 +39,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_upgrade_docker: update/docker.adoc
 :url_upgrade_source: update/source.adoc
 :url_getting_started: setup/index.adoc
-:url_config_api: management/api-access.adoc
+
 
 image:banner_core.png[Logo]
 
@@ -78,7 +85,7 @@ Node operators are required to set up Lisk Core on a server, and then connect it
 
 There are over 600 nodes around the world that are maintained by individuals, and these nodes communicate with the network.
 For example, by broadcasting and receiving blocks or transactions from their peers.
-In addition, Lisk nodes are also required to forge/add new blocks to the blockchain.
+In addition, Lisk nodes are also required to xref:{url_protocol_forging}[forge]/add new blocks to the blockchain.
 It is possible to view the live network statistics by accessing the following URL: {url_explorer}[Lisk’s Blockchain Explorer].
 
 === Who should operate a node?
@@ -86,7 +93,7 @@ It is possible to view the live network statistics by accessing the following UR
 If you fall under one of the following categories listed below, then it is recommended to set up your own node:
 
 * *Exchanges* and other services that rely on a stable API interface to the network.
-* *Delegates* who have registered as a delegate and would like to actively forge.
+* *Delegates* who have registered as a delegate and would like to actively xref:{url_protocol_forging}[forge].
 * *Users* who do not trust external sources and want to be in full control over their node.
 
 === Why operate a node?
@@ -97,7 +104,7 @@ There are several advantages why one would wish to set up a node, and these are 
 This is especially important when running an exchange and implementing LSK tokens.
 - To acquire full control in order to xref:{url_config}[configure] the node to your specific requirements.
 - To create your own xref:{url_snapshots}[snapshots][[Snapshots]] of the blockchain.
-- To have the option to xref:{url_config_forging}[forge] new blocks, (assuming you are an active xref:{url_config_forging}[delegate]).
+- To have the option to xref:{url_config_forging}[forge] new blocks, (assuming you are an active delegate)
 
 NOTE: To learn how to set up a node, please go to the xref:{url_getting_started}[setup overview] page.
 
@@ -163,7 +170,7 @@ A snapshot is a backup of the complete blockchain.
 It can be used to speed up the synchronization process, instead of having to validate all transactions starting from the genesis block to the current block height.
 Lisk provides official snapshots of the blockchain which can be found in the following link: {url_lisk_snapshots}
 
-How to both rebuild from a snapshot, and to create your own snapshots is explained in the respective section for each <<distributions, distribution>> of the Lisk Core.
+How to rebuild from a snapshot and to create your own snapshots is explained in the administration section for each xref:{}[distribution] of the Lisk Core.
 
 TIP: It is recommended to use xref:{url_admin_binary_snapshot}[Lisk Core Application] for creating your own snapshots, as a script is provided to conveniently create snapshots.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,14 +3,12 @@ Mona Bärenfänger <mona@lightcurve.io>
 :description: The introduction page describes Lisk Core and the different networks, distributions and general technology stack of Lisk Core.
 :imagesdir: ./../assets/images
 :toc:
-:page-aliases: troubleshooting.adoc
+:page-aliases: troubleshooting.adoc, getting-started.adoc
 :page-no-previous: true
 :page-next: /lisk-core/interact-with-the-api.html
 :page-next-title: Interact with the API
-:page-no-previous: true
+
 :v_sdk: master
-:page-aliases: monitoring.adoc
-:page-aliases: migration.adoc
 
 :url_explorer: https://explorer.lisk.io
 :url_explorer_testnet: https://testnet-explorer.lisk.io
@@ -170,7 +168,7 @@ A snapshot is a backup of the complete blockchain.
 It can be used to speed up the synchronization process, instead of having to validate all transactions starting from the genesis block to the current block height.
 Lisk provides official snapshots of the blockchain which can be found in the following link: {url_lisk_snapshots}
 
-How to rebuild from a snapshot and to create your own snapshots is explained in the administration section for each xref:{}[distribution] of the Lisk Core.
+How to both rebuild from a snapshot, and to create your own snapshots is explained in the respective section for each <<distributions, distribution>> of the Lisk Core.
 
 TIP: It is recommended to use xref:{url_admin_binary_snapshot}[Lisk Core Application] for creating your own snapshots, as a script is provided to conveniently create snapshots.
 

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -5,6 +5,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :toc:
 :imagesdir: ../assets/images
 :v_sdk: master
+:url_api: https://swagger.io/
 :url_curl: https://curl.haxx.se/
 :url_postman: https://www.getpostman.com/
 :url_lisk_wallet: https://lisk.io/wallet
@@ -12,7 +13,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_explorer: https://explorer.lisk.io
 :url_explorer_testnet: https://testnet-explorer.lisk.io
 
-:url_api: reference/api.adoc
 :url_maintain_node: index.adoc#node
 :url_elements_pkg_api: {v_sdk}@lisk-sdk::references/lisk-elements/api-client.adoc
 :url_elements: {v_sdk}@lisk-sdk::references/lisk-elements/index.adoc

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -4,7 +4,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :toc:
 :imagesdir: ../assets/images
 :v_sdk: master
-:url_api: https://swagger.io/
 :url_curl: https://curl.haxx.se/
 :url_postman: https://www.getpostman.com/
 :url_lisk_wallet: https://lisk.io/wallet
@@ -12,13 +11,14 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_explorer: https://explorer.lisk.io
 :url_explorer_testnet: https://testnet-explorer.lisk.io
 
+:url_api: reference/api.adoc
 :url_maintain_node: index.adoc#node
 :url_elements_pkg_api: {v_sdk}@lisk-sdk::references/lisk-elements/api-client.adoc
 :url_elements: {v_sdk}@lisk-sdk::references/lisk-elements/index.adoc
 :url_elements_pkg: {v_sdk}@lisk-sdk::references/lisk-elements/index.adoc
 :url_commander: {v_sdk}@lisk-sdk::references/lisk-commander/index.adoc
 :url_commander_commands: {v_sdk}@lisk-sdk::references/lisk-commander/commands.adoc
-:url_config_api_access: management/configuration.adoc#api_access
+:url_config_api_access: {v_sdk}@lisk-sdk::guide/node-management/api-access.adoc
 
 == What does it mean to interact with the network?
 

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -19,7 +19,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_elements_pkg: {v_sdk}@lisk-sdk::references/lisk-elements/index.adoc
 :url_commander: {v_sdk}@lisk-sdk::references/lisk-commander/index.adoc
 :url_commander_commands: {v_sdk}@lisk-sdk::references/lisk-commander/commands.adoc
-:url_config_api_access: {v_sdk}@lisk-sdk::guide/node-management/api-access.adoc
+:url_config_api_access: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc
 
 == What does it mean to interact with the network?
 

--- a/modules/ROOT/pages/management/configuration.adoc
+++ b/modules/ROOT/pages/management/configuration.adoc
@@ -7,9 +7,13 @@ Mona Bärenfänger <mona@lightcurve.io>
 
 :url_config_clo: reference/config.adoc#clo
 :url_config_structure: reference/config.adoc#structure
-:url_sdk_framework: {v_sdk}@lisk-sdk::references/lisk-framework/index.adoc
 :url_management_docker_config: management/docker.adoc#config
-
+:url_management_api: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc
+:url_management_forging: management/forging.adoc
+:url_management_logging: {v_sdk}@lisk-sdk::guides/node-management/logging.adoc
+:url_management_ssl: {v_sdk}@lisk-sdk::guides/node-management/enable-ssl.adoc
+:url_sdk_framework: {v_sdk}@lisk-sdk::references/lisk-framework/index.adoc
+:url_source: management/source.adoc
 
 [IMPORTANT]
 ====
@@ -103,3 +107,9 @@ Each configuration will override the previous one:
 For development purposes, use `devnet` as the network option.
 Other networks are specific to public Lisk networks.
 
+== Further management guides
+
+* xref:{url_management_api}[API access]
+* xref:{url_management_forging}[Forging]
+* xref:{url_management_logging}[Logging]
+* xref:{url_management_ssl}[SSL]

--- a/modules/ROOT/pages/management/forging.adoc
+++ b/modules/ROOT/pages/management/forging.adoc
@@ -1,155 +1,27 @@
 = Enable forging
 Mona Bärenfänger <mona@lightcurve.io>
-:description: A guide that describes how to check, enable and disable forging on a node.
+:description: This page describes how to check, enable and disable forging on a node.
 :toc:
 :v_sdk: master
-:url_sdk_commander_commands: {v_sdk}@lisk-sdk::references/lisk-commander/commands.adoc
-:url_sdk_elements_cryptography: {v_sdk}@lisk-sdk::references/lisk-elements/cryptography.adoc
 
-To enable your node to forge, firstly it is required to insert some encrypted data into the config file under the `chain.forging.delegates` array.
-To encrypt your passphrase, it is recommended to use one of the following options listed below:
+:url_sdk_guides_forging: {v_sdk}@lisk-sdk::guides/node-management/forging.adoc
 
-* xref:{url_sdk_commander_commands}[Lisk Commander] via `encrypt passphrase` command.
-* xref:{url_sdk_elements_cryptography}[Cryptography module of Lisk Elements]
+Please refer to this guide how to xref:{url_sdk_guides_forging}[enable forging on a Lisk node].
 
-The first option with Lisk Commander is described in detail below.
-Please ensure that Lisk Commander is installed in a secure environment.
-Upon completion, follow the commands listed below to generate the encrypted passphrase:
+[IMPORTANT]
 
-[source,bash]
-----
-$ lisk
-lisk passphrase:encrypt --outputPublicKey
-Please enter your secret passphrase: ***** <1>
-Please re-enter your secret passphrase: *****
-Please enter your password: *** <2>
-Please re-enter your password: ***
-{
-        "encryptedPassphrase": "iterations=1000000&cipherText=30a3c8&iv=b0d7322bf24e0dfe08462f4f&salt=aa7e26c9f4317b61b4f45b5c6909f941&tag=a2e0eadaf1f11a10b342965bc3bafc68&version=1",
-        "publicKey": "a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd"
-}
-----
+Keep in mind you need to use the right ports for the network that your Lisk Core node is connected to.
+A reference of all HTTP ports of Lisk Core can be seen below:
 
-<1> Enter the secret passphrase here that needs to be encrypted.
-<2> Enter the password here that will be required to decrypt the passphrase again.
+.HTTP ports
+****
+The HTTP Port can be different based on your configuration, therefore it is recommended to check the `httpPort` in your config.
 
-* Type in your passphrase followed by the password required for encryption.
-* This will result in the creation of an `encryptedPassphrase` key-value pair.
-* Create the JSON object and add it to your `config.json` under `chain.forging.delegates` as can be seen below:
+The *default ports* for the different networks are:
 
-[source,js,linenums]
-----
-{
-  "modules": {
-    "chain": { <1>
-      "forging": { <2>
-        "force": false, <3>
-        "delegates": [ <4>
-            {
-                "encryptedPassphrase": "iterations=1&salt=476d4299531718af8c88156aab0bb7d6&cipherText=663dde611776d87029ec188dc616d96d813ecabcef62ed0ad05ffe30528f5462c8d499db943ba2ded55c3b7c506815d8db1c2d4c35121e1d27e740dc41f6c405ce8ab8e3120b23f546d8b35823a30639&iv=1a83940b72adc57ec060a648&tag=b5b1e6c6e225c428a4473735bc8f1fc9&version=1",
-                "publicKey": "9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f"
-            }
-        ],
-      },
-    },
-    "http_api": { <5>
-      "forging": {
-        "access": {
-          "whiteList": ["127.0.0.1", "REPLACE_ME"], <6>
-        },
-      },
-    }
-  }
-}
-----
+* 4000 (Devnet)
+* 5000 (Betanet)
+* 7000 (Testnet)
+* 8000 (Mainnet)
+****
 
-<1> Contains options for the chain module.
-<2> Contains forging options for delegates.
-<3> Forces forging to be 'on'.
-This is only used on local development networks.
-<4> The list of delegates who are allowed to forge on this node.
-To successfully enable forging for a delegate, the public key and the encrypted passphrase need to be deposited here as a JSON object.
-<5> Contains options for the API module.
-<6> Replace with the IP which will be used to access your node.
-
-
-Finally, reload your Lisk Core process to make the changes in the config effective.
-For example, for the Lisk Core application, execute the following command: `bash lisk.sh reload`
-
-[[check_forging]]
-== Check forging
-
-Use the following `curl` command to verify the forging status of your delegate as shown below:
-
-[source,bash]
-----
-curl \
-  http://127.0.0.1:7000/api/node/status/forging \
-  -H 'cache-control: no-cache' \
-  -H 'content-type: application/json'
-----
-
-The result should appear as shown below in the following code snippet:
-
-[source,json,linenums]
-----
-{
-  "meta": {},
-  "data": [
-    {
-      "forging": true,
-      "publicKey": "9bc945f92141d5e11e97274c275d127dc7656dda5c8fcbf1df7d44827a732664"
-    }
-  ],
-  "links": {}
-}
-----
-
-[[forging_enable_disable]]
-== Enable/Disable forging
-
-IMPORTANT: Remember that after restarting your Lisk node, it is necessary to re-enable forging again.
-
-[TIP]
-====
-The endpoint to perform this action is *idempotent*.
-
-This means that the results are identical, regardless of how many times the query is executed.
-====
-
-If your Lisk node is running on a local machine, it is possible to enable forging through the API client, without any further interruption.
-
-Use the following curl command to *enable the forging* for your delegate as shown below:
-
-[source,bash]
-----
-curl -X PUT \
-  http://127.0.0.1:7000/api/node/status/forging \
-  -H 'cache-control: no-cache' \
-  -H 'content-type: application/json' \
-  -d '{
-          "publicKey": "YYYYYYYYY",
-          "password": "XXX",
-          "forging": true
-      }'
-----
-
-Use the following curl command to *disable the forging* for your delegate as shown below:
-
-[source,bash]
-----
-curl -X PUT \
-  http://127.0.0.1:7000/api/node/status/forging \
-  -H 'cache-control: no-cache' \
-  -H 'content-type: application/json' \
-  -d '{
-          "publicKey": "YYYYYYYYY",
-          "password": "XXX",
-          "forging": false
-      }'
-----
-
-* `publicKey` is the key for the delegate which is required to be enabled/disabled.
-* `password` is the password used to encrypt your passphrase in `config.json`.
-* `forging` is the boolean value to enable or disable the forging.
-* The HTTP Port can be different based on your configuration, therefore it is recommended to check the `httpPort` in your `config.json`.

--- a/modules/ROOT/pages/migration.adoc
+++ b/modules/ROOT/pages/migration.adoc
@@ -9,7 +9,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_lisk_bridge_mainnet: https://downloads.lisk.io/lisk/main/lisk_bridge.sh
 :url_lisk_bridge_testnet: https://downloads.lisk.io/lisk/test/lisk_bridge.sh
 :url_lisk_downloads: https://downloads.lisk.io/lisk/
-
 :url_admin_binary_rebuild_from_genesis: management/application.adoc#rebuild_from_genesis
 :url_configuration_forging: management/configuration.adoc#forging_enable_disable
 :url_distributions: index.adoc#distributions

--- a/modules/ROOT/pages/migration.adoc
+++ b/modules/ROOT/pages/migration.adoc
@@ -4,7 +4,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :toc:
 :page-previous: /lisk-core/management/configuration.html
 :page-previous-title: Configuration
-:v_sdk: master
 
 :url_lisk_bridge_mainnet: https://downloads.lisk.io/lisk/main/lisk_bridge.sh
 :url_lisk_bridge_testnet: https://downloads.lisk.io/lisk/test/lisk_bridge.sh

--- a/modules/ROOT/pages/migration.adoc
+++ b/modules/ROOT/pages/migration.adoc
@@ -4,6 +4,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :toc:
 :page-previous: /lisk-core/management/configuration.html
 :page-previous-title: Configuration
+:v_sdk: master
 
 :url_lisk_bridge_mainnet: https://downloads.lisk.io/lisk/main/lisk_bridge.sh
 :url_lisk_bridge_testnet: https://downloads.lisk.io/lisk/test/lisk_bridge.sh

--- a/modules/ROOT/pages/setup/application.adoc
+++ b/modules/ROOT/pages/setup/application.adoc
@@ -1,4 +1,4 @@
-= Application set up
+= Application
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Lisk Core application setup describes all necessary steps and requirements to install the Lisk SDK.
 :toc:
@@ -7,12 +7,11 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-next-title: Application commands
 
 :url_dev_forum: https://dev.lisk.io/
-
 :url_upgrade_binary: update/application.adoc
 :url_admin_binary: management/application.adoc
-:url_config_api_access: management/api-access.adoc
+:url_config_api_access: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc
 :url_config: management/configuration.adoc
-:url_config_logrotation: management/logs.adoc#logrotation
+:url_config_logrotation: {v_sdk}@lisk-sdk::guides/node-management/logging.adoc#logrotation
 
 This document details how to setup a Lisk Core application on a system.
 
@@ -135,7 +134,6 @@ It is possible to verify that your Lisk node is up and running, by executing the
 ----
 bash lisk.sh status
 ----
-
 For further information and how to administer your Lisk node, please see the xref:{url_admin_binary}[Management section].
 
 If you are not running Lisk locally, you will need to follow the xref:{url_config_api_access}[API configuration] document to enable access.

--- a/modules/ROOT/pages/setup/commander.adoc
+++ b/modules/ROOT/pages/setup/commander.adoc
@@ -1,4 +1,4 @@
-= Commander application set up
+= Commander application
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Lisk Core Commander application setup describes all necessary steps and requirements to install the Lisk SDK via Lisk Commander.
 :toc:
@@ -14,8 +14,8 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_sdk_commander_commands: {v_sdk}@lisk-sdk::references/lisk-commander/commands.adoc
 :url_binary_download: https://downloads.lisk.io/lisk/mainnet/{v_core}/
 :url_snapshots: index.adoc#snapshots
-:url_config_logrotation: management/logs.adoc#logrotation
-:url_config_api_access: management/api-access.adoc#api-access
+:url_config_logrotation: {v_sdk}@lisk-sdk::guides/node-management/logging.adoc#logrotation
+:url_config_api_access: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc#api-access
 :url_config: management/configuration.adoc
 
 Setup and manage your Lisk Core conveniently with Lisk Commander.
@@ -160,6 +160,6 @@ Check you network settings to verify the corresponding ports are open.
 
 In addition it is also recommended to set up a xref:{url_config_logrotation}[log rotation].
 
-If you are not running Lisk locally, you will need to follow the xref:{url_config_api_access}[API - Configuration] guide to enable access.
+If you are not running Lisk locally, you will need to follow the xref:{url_config_api_access}[Control API access] guide to enable access.
 
 Assuming all of the above steps have been successfully completed, then the next step is to move on to the configuration documentation. If you wish to enable forging or SSL, please see the xref:{url_config}[General configuration].

--- a/modules/ROOT/pages/setup/docker.adoc
+++ b/modules/ROOT/pages/setup/docker.adoc
@@ -1,4 +1,4 @@
-= Docker image set up
+= Docker image setup
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Lisk Core Docker image setup describes all necessary steps and requirements to install the Lisk SDK with Docker.
 :toc:
@@ -171,7 +171,7 @@ docker-compose logs  <3>
 
 === Verify
 
-The final step here is to verify that your node is connected, and is synchronized with the network, e.g. inquiring about your node's status from using the API as shown below:
+The final step is now to verify that your node is connected, and is synchronized with the network, e.g. inquiring about your node's status from using the API as shown below:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/setup/index.adoc
+++ b/modules/ROOT/pages/setup/index.adoc
@@ -1,6 +1,6 @@
-= How to maintain a node
+= Setup
 Mona Bärenfänger <mona@lightcurve.io>
-:description: Learn how to maintain a Lisk node and also when it is recommended to run a specific node.
+:description: Learn how to setup and maintain a Lisk node and also when it is recommended to run a specific node.
 :page-aliases: getting-started/maintain-a-node.adoc
 :toc:
 :page-previous: /lisk-core/index.html

--- a/modules/ROOT/pages/setup/source.adoc
+++ b/modules/ROOT/pages/setup/source.adoc
@@ -1,4 +1,4 @@
-= Source code set up
+= Source code setup
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Lisk Core Source code setup describes all necessary steps and requirements to install the Lisk SDK from source.
 :toc:
@@ -6,6 +6,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-previous: /lisk-core/interact-with-network.html
 :page-next-title: Source code commands
 :page-previous-title: Interact with the network
+:v_sdk: master
 
 :url_core_releases: https://github.com/LiskHQ/lisk-core/releases
 :url_git: https://github.com/git/git
@@ -15,10 +16,9 @@ Mona Bärenfänger <mona@lightcurve.io>
 :url_nvm_instructions: https://github.com/creationix/nvm#install--update-script
 :url_pm2: https://github.com/Unitech/pm2
 :url_xcode: https://developer.apple.com/xcode/
-
 :url_admin: management/index.adoc
 :url_binary_pre_install: setup/application.adoc
-:url_config_api: management/api-access.adoc
+:url_config_api: {v_sdk}@lisk-sdk::guides/node-management/api-access.adoc
 :url_core_config: management/configuration.adoc
 :url_docker_setup: setup/docker.adoc
 :url_environment_variables: setup/docker.adoc#environment_variables

--- a/modules/ROOT/pages/update/application.adoc
+++ b/modules/ROOT/pages/update/application.adoc
@@ -1,4 +1,4 @@
-= Update Application
+= Application
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Lisk Core application update page describes how to upgrade Lisk Core to the latest version.
 :page-aliases: upgrade/binary.adoc

--- a/modules/ROOT/pages/update/commander.adoc
+++ b/modules/ROOT/pages/update/commander.adoc
@@ -1,4 +1,4 @@
-= Update Commander application
+= Commander application
 Mona Bärenfänger <mona@lightcurve.io>
 :description:  Describes how to update Lisk Core to the latest version via Lisk Commander.
 :page-aliases: upgrade/commander.adoc

--- a/modules/ROOT/pages/update/docker.adoc
+++ b/modules/ROOT/pages/update/docker.adoc
@@ -1,4 +1,4 @@
-= Update Docker image
+= Docker image
 Mona Bärenfänger <mona@lightcurve.io>
 :description: Describes how to update Lisk Core to the latest version with Docker.
 :page-aliases: upgrade/docker.adoc

--- a/modules/ROOT/pages/update/source.adoc
+++ b/modules/ROOT/pages/update/source.adoc
@@ -1,4 +1,4 @@
-= Update Source code
+= Source code
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The Source code update page describes how to upgrade Lisk Core to the latest version from source.
 :page-aliases: upgrade/source.adoc
@@ -7,6 +7,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-previous: /lisk-core/management/source.html
 :page-next-title: Monitoring
 :page-previous-title: Source code commands
+:v_sdk: master
 
 :url_core_releases: https://github.com/LiskHQ/lisk-core/releases
 :url_tagged_releases: https://github.com/LiskHQ/lisk-core/releases

--- a/modules/ROOT/pages/update/source.adoc
+++ b/modules/ROOT/pages/update/source.adoc
@@ -7,7 +7,6 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-previous: /lisk-core/management/source.html
 :page-next-title: Monitoring
 :page-previous-title: Source code commands
-:v_sdk: master
 
 :url_core_releases: https://github.com/LiskHQ/lisk-core/releases
 :url_tagged_releases: https://github.com/LiskHQ/lisk-core/releases


### PR DESCRIPTION
Which content is outdated?
The content in the management guides is partly redundant with the guides in the SDK docs.

What should be the new content?
Update the Lisk Core documentation (e.g. add references to the Lisk SDK documentation) so that only Lisk Core specific topics are being covered in it.

For the general guides, refer to the Lisk SDK docs.





Closes #731 
