### PR TITLE
Revisit meta page descriptions in SDK docs - closes #759 

### DIFF
--- a/modules/ROOT/pages/explanations/consensus.adoc
+++ b/modules/ROOT/pages/explanations/consensus.adoc
@@ -1,6 +1,6 @@
 = Consensus in Lisk
 Mona Bärenfänger <mona@lightcurve.io>
-:description: This section provides an overview of the main guides in chronological order, together with an example using the 'Hello World' App.
+:description: Delegated proof of stake,forging,registering and voting, together with explaining BFT is covered here.
 :toc:
 :imagesdir: ../../../assets/images
 :v_protocol: master

--- a/modules/ROOT/pages/explanations/framework.adoc
+++ b/modules/ROOT/pages/explanations/framework.adoc
@@ -1,6 +1,6 @@
 = Lisk Framework
 Mona Bärenfänger <mona@lightcurve.io>
-:description: The Lisk Framework overview provides a high-level synopsis of the Lisk Framework architecture, including its modules and components, how they communicate, and also how to change the default configuration.
+:description: Lisk Framenwork includes the architecture, application, modules, components & configuration option details for associated interactions with a Lisk blockchain application.
 :page-aliases: lisk-framework/index.adoc
 :toc: preamble
 :v_core: 3.0.0

--- a/modules/ROOT/pages/guides/app-development/broadcast.adoc
+++ b/modules/ROOT/pages/guides/app-development/broadcast.adoc
@@ -1,6 +1,6 @@
 = Broadcast a transaction
 Mona Bärenfänger <mona@lightcurve.io>
-:description: This guide covers how to create a transaction object and broadcast it to the network.
+:description: How to create, sign and broadcast a transaction object to the network.
 :toc:
 :sectnums:
 :v_protocol: master

--- a/modules/ROOT/pages/guides/app-development/configuration.adoc
+++ b/modules/ROOT/pages/guides/app-development/configuration.adoc
@@ -1,6 +1,6 @@
 = Configure a blockchain application
 Mona Bärenfänger <mona@lightcurve.io>
-:description: The Lisk SDK Configuration page describes how to configure a blockchain application developed with the Lisk SDK.
+:description: All configuration options, constants, and the devnet genesis block which are relevant for configuring a blockchain application.
 :page-aliases: configuration.adoc
 :toc:
 :v_sdk: v4.0.0-alpha.1


### PR DESCRIPTION
Most meta descriptions of pages in the SDK documentation need to be updated in order to improve the SEO value.


Parent issue #738