### PR TITLE
Fix previous links on tutorial index in SDK docs 4.0.0 - Closes #820

### DIFF
--- a/modules/ROOT/pages/tutorials/index.adoc
+++ b/modules/ROOT/pages/tutorials/index.adoc
@@ -3,7 +3,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :description: The SDK Tutorials overview gives a summary of the Hello World & Supply Chain apps, including the complexity, the estimated time required, and the content.
 :toc:
 :page-aliases: tutorials/cashback.adoc
-:page-previous: /lisk-sdk/guides.html
+:page-previous: /lisk-sdk/v4/guides/index.html
 :page-previous-title: Guides
 
 :url_tutor: tutorials/hello-world.adoc


### PR DESCRIPTION
Closes #820 