### PR TITLE
Add 'signDataWithPrivateKey' to cryptography reference in SDK docs v5 - Closes #876

### DIFF
--- a/modules/ROOT/pages/references/lisk-elements/cryptography.adoc
+++ b/modules/ROOT/pages/references/lisk-elements/cryptography.adoc
@@ -839,6 +839,17 @@ Returns a legacy address converted from the private key
 getLegacyAddressFromPrivateKey: (privateKey: Buffer) => string;
 ----
 
+=== signDataWithPrivateKey
+
+Signs the data with the private key
+
+==== Syntax
+
+[source,js]
+----
+signDataWithPrivateKey: (data: Buffer, privatekey: Buffer) => Buffer signDetached(data, privateKey);
+----
+
 == Methods for signing and verifying
 
 === validateBase32Address


### PR DESCRIPTION








Parent issue #876