### PR TITLE
Fix broken link in supply chain in SDK docs 3.0.2 - Closes #914

### DIFF
--- a/modules/ROOT/pages/tutorials/supply-chain/part4.adoc
+++ b/modules/ROOT/pages/tutorials/supply-chain/part4.adoc
@@ -22,6 +22,7 @@
 :url_core_config_forging_enable: {v_core}@lisk-core::management/forging.adoc#forging_enable_disable
 :url_setup_ports: setup.adoc#ports
 :url_tutorials_transport_2: tutorials/supply-chain/part3.adoc
+:url_configuration: guides/app-development/configuration.adoc
 
 In part 4, the next steps required after the initial development of the application are covered here.
 
@@ -94,7 +95,7 @@ Exchange the `configDevnet` object that was passed to the node during the develo
 [TIP]
 ====
 It is recommended to create a config object with all the options that are different to the default config options.
-To check the default config options, go to the xref:config.adoc[configuration page] or check it directly in the code listed below: +
+To check the default config options, go to the xref:{url_configuration}[configuration page] or check it directly in the code listed below: +
 `lisk-framework/src/modules/MODULE_NAME/defaults/config.js`. +
 The same for the components as shown below: +
 `lisk-framework/src/components/COMPONENT_NAME/defaults/config.js`.


### PR DESCRIPTION
The reference link to the configuration page is broken in the supply chain section.


Closes #914   