### PR TITLE
Corrections for broken link in Validator in SDK docs 5.0.3 -Closes #927

### DIFF
--- a/modules/ROOT/pages/references/lisk-elements/validator.adoc
+++ b/modules/ROOT/pages/references/lisk-elements/validator.adoc
@@ -2,7 +2,7 @@
 :description: This section contains the installation, updates and usage for the Lisk validator.
 :toc:
 :v_protocol: master
-:url_lisk_protocol: protocol:lisk-protocol/index.adoc
+:url_lisk_protocol: protocol/pages/index.adoc
 
 The @liskhq/lisk-validator package is a wrapper of validation packages.
 It includes custom validations utilities related to the xref:{url_lisk_protocol}[Lisk Protocol].

--- a/modules/ROOT/pages/references/lisk-elements/validator.adoc
+++ b/modules/ROOT/pages/references/lisk-elements/validator.adoc
@@ -2,7 +2,7 @@
 :description: This section contains the installation, updates and usage for the Lisk validator.
 :toc:
 :v_protocol: master
-:url_lisk_protocol: protocol/pages/index.adoc
+:url_lisk_protocol: protocol:index.adoc
 
 The @liskhq/lisk-validator package is a wrapper of validation packages.
 It includes custom validations utilities related to the xref:{url_lisk_protocol}[Lisk Protocol].
@@ -70,4 +70,3 @@ isSInt64
 isUInt64
 isBytes
 ----
-


### PR DESCRIPTION
Fixes broken link to Lisk Protocol in Validator page.


Closes #927 