### PR TITLE
Outdated example for peers in Lisk core docs 3.0.0-beta.4 - Closes # 965

### DIFF
--- a/modules/ROOT/pages/reference/api.adoc
+++ b/modules/ROOT/pages/reference/api.adoc
@@ -2,4 +2,7 @@
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The API endpoints of Lisk Core nodes connected to the Betanet are covered here, including sending requests and receiving live responses.
 :page-layout: swagger
-:page-swagger-url: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.0-alpha.5/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+:page-swagger-url: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.3/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+
+
+


### PR DESCRIPTION
This is not an issue we can fix in the Lisk docs repository.
 Could you please open an issue for it in the Lisk SDK repository, as it needs to be fixed in the swagger.yml file.



refer to: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.3/framework-plugins/lisk-framework-http-api-plugin/swagger.yml

Closes #965 