### PR TITLE
Outdated example for peers in Lisk core docs v3.0.0 beta.4 - closes #929

### DIFF
--- a/modules/ROOT/pages/reference/api.adoc
+++ b/modules/ROOT/pages/reference/api.adoc
@@ -4,5 +4,3 @@ Mona Bärenfänger <mona@lightcurve.io>
 :page-layout: swagger
 :page-swagger-url: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.3/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
 
-
-

--- a/modules/ROOT/pages/reference/api.adoc
+++ b/modules/ROOT/pages/reference/api.adoc
@@ -2,4 +2,7 @@
 Mona Bärenfänger <mona@lightcurve.io>
 :description: The API endpoints of Lisk Core nodes connected to the Betanet are covered here, including sending requests and receiving live responses.
 :page-layout: swagger
-:page-swagger-url: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.0-alpha.5/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+:page-swagger-url: https://raw.githubusercontent.com/LiskHQ/lisk-sdk/v5.0.3/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+
+
+


### PR DESCRIPTION
This PR replaces #965 with the correct branch name required for merging







Closes #929