### PR TITLE
Fix API links

### DIFF
--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -91,7 +91,7 @@ The source code of Lisk Explorer is open source, and hence can be utilized to se
 [[api]]
 === E - Query the API
 
-Query the {url_api}[API] manually.
+Query the xref:{url_api}[API] manually.
 Either from a public node, or connect to your own private node to interact with the network.
 
 TIP: To view the full specification of the Lisk Core API including example queries, please see the {url_api}[Lisk Core API].

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -5,7 +5,8 @@ Mona Bärenfänger <mona@lightcurve.io>
 :toc:
 :imagesdir: ../assets/images
 :v_sdk: master
-:url_api: https://swagger.io/
+:url_swagger: https://swagger.io/
+:url_api: https://lisk.io/documentation/lisk-core/reference/api-mainnet.html
 :url_curl: https://curl.haxx.se/
 :url_postman: https://www.getpostman.com/
 :url_lisk_wallet: https://lisk.io/wallet
@@ -90,16 +91,16 @@ The source code of Lisk Explorer is open source, and hence can be utilized to se
 [[api]]
 === E - Query the API
 
-Query the xref:{url_api}[API] manually.
+Query the {url_api}[API] manually.
 Either from a public node, or connect to your own private node to interact with the network.
 
-TIP: To view the full specification of the Lisk Core API including example queries, please see the xref:{url_api}[Lisk Core API].
+TIP: To view the full specification of the Lisk Core API including example queries, please see the {url_api}[Lisk Core API].
 
 To execute the query, use any applicable tool that is suitable for HTTP API requests.
 
 *Popular tools for HTTP requests can be seen below:*
 
-* {url_api}[Swagger UI]: This is a Web interface that can send API requests, in addition to providing the complete API specification.
+* {url_swagger}[Swagger UI]: This is a Web interface that can send API requests, in addition to providing the complete API specification.
 * {url_curl}[Curl]: This performs API requests from the command-line.
 * {url_postman}[Postman]: This is a user friendly graphical interface for sending API requests.
 

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -94,7 +94,7 @@ The source code of Lisk Explorer is open source, and hence can be utilized to se
 Query the xref:{url_api}[API] manually.
 Either from a public node, or connect to your own private node to interact with the network.
 
-TIP: To view the full specification of the Lisk Core API including example queries, please see the {url_api}[Lisk Core API].
+TIP: To view the full specification of the Lisk Core API including example queries, please see the xref:{url_api}[Lisk Core API].
 
 To execute the query, use any applicable tool that is suitable for HTTP API requests.
 

--- a/modules/ROOT/pages/interact-with-the-api.adoc
+++ b/modules/ROOT/pages/interact-with-the-api.adoc
@@ -6,7 +6,7 @@ Mona Bärenfänger <mona@lightcurve.io>
 :imagesdir: ../assets/images
 :v_sdk: master
 :url_swagger: https://swagger.io/
-:url_api: https://lisk.io/documentation/lisk-core/reference/api-mainnet.html
+:url_api: reference/api-mainnet.adoc
 :url_curl: https://curl.haxx.se/
 :url_postman: https://www.getpostman.com/
 :url_lisk_wallet: https://lisk.io/wallet


### PR DESCRIPTION
Changed 
`:url_api` to `https://lisk.io/documentation/lisk-core/reference/api-mainnet.html` — may be it is better to use some shortcut.
`:url_swagger:` to `https://swagger.io/`

`{url_config_api_access}` still does not work.