### PR TITLE
Fixed broken Docker instructions for core v3.0-beta5

### DIFF
--- a/modules/ROOT/pages/setup/docker.adoc
+++ b/modules/ROOT/pages/setup/docker.adoc
@@ -46,7 +46,7 @@ For example, use `apt-get` if running Ubuntu as shown in the following command b
 
 [source,bash]
 ----
-sudo apt-get install curl make
+sudo apt-get install curl make jq
 ----
 --
 MacOS::
@@ -116,13 +116,13 @@ Clone the {url_lisk_core_repository}[Lisk Core repository^] as shown below:
 sudo -u lisk -i                                    <1>
 git clone https://github.com/LiskHQ/lisk-core.git  <2>
 cd lisk-core/docker                                <3>
-git checkout v3.0.0-beta.1                         <4>
+git checkout v3.0.0-beta.5                         <4>
 ----
 
 <1> Switch to the `lisk` user.
 <2> Clone the repository.
 <3> Navigate into the docker directory.
-<4> Checkout the `3.0.0-beta.1` branch.
+<4> Checkout the `3.0.0-beta.5` branch.
 
 This contains a directory `docker` with the following files:
 


### PR DESCRIPTION
The instructions seemed to be outdated and I took the chance to fix them