### PR TITLE
Change payload size limit unit from "kB" to "KiB"

### DIFF
--- a/modules/protocol/pages/blocks.adoc
+++ b/modules/protocol/pages/blocks.adoc
@@ -46,7 +46,7 @@ When updating the account state with a block, the transactions in the payload ar
 This order is also used to assert the validity of the payload.
 Indeed, transactions have to be valid with respect to the blockchain state obtained by applying all previous blocks and all previous transactions in the payload.
 
-In the Lisk protocol, the payload size is limited to 15 KB (15 x 1024 bytes).
+In the Lisk protocol, the payload size is limited to 15 KiB (15 x 1024 bytes).
 
 
 == Block header

--- a/modules/protocol/pages/blocks.adoc
+++ b/modules/protocol/pages/blocks.adoc
@@ -46,7 +46,7 @@ When updating the account state with a block, the transactions in the payload ar
 This order is also used to assert the validity of the payload.
 Indeed, transactions have to be valid with respect to the blockchain state obtained by applying all previous blocks and all previous transactions in the payload.
 
-In the Lisk protocol, the payload size is limited to 15 kB.
+In the Lisk protocol, the payload size is limited to 15 KB.
 
 
 == Block header

--- a/modules/protocol/pages/blocks.adoc
+++ b/modules/protocol/pages/blocks.adoc
@@ -46,7 +46,7 @@ When updating the account state with a block, the transactions in the payload ar
 This order is also used to assert the validity of the payload.
 Indeed, transactions have to be valid with respect to the blockchain state obtained by applying all previous blocks and all previous transactions in the payload.
 
-In the Lisk protocol, the payload size is limited to 15 KB.
+In the Lisk protocol, the payload size is limited to 15 KB (15 x 1024 bytes).
 
 
 == Block header


### PR DESCRIPTION
The payload size limit must be 15 KiB (15 x 1024 bytes) instead 15 kB (15 x 1000 bytes).