### PR TITLE
Tiny message change to make error clearer.

### DIFF
--- a/modules/ROOT/pages/tutorials/srs.adoc
+++ b/modules/ROOT/pages/tutorials/srs.adoc
@@ -341,7 +341,7 @@ class CreateRecoveryAsset extends BaseAsset {
         }
         const sameAccount = asset.friends.find(f => f === sender.address);
         if (sameAccount) {
-            throw new Error('You cannot add yourself to the friend list.');
+            throw new Error('You cannot add yourself to your own friend list.');
         }
         // Add friends to the list
         sender.srs.config.friends = [...asset.friends.sort()];


### PR DESCRIPTION
"the friends list" could be someone else's list. this error out of context in the console could be confusing.