### PR TITLE
Update keys-module.adoc - wrong module name

### DIFF
--- a/modules/ROOT/pages/keys-module.adoc
+++ b/modules/ROOT/pages/keys-module.adoc
@@ -34,7 +34,7 @@ a|
 
 == Account schema
 
-The token module adds the new property `mandatoryKeys`,`optionalKeys` and `numberOfSignatures` under the key `keys` to every account in the network as follows:
+The keys module adds the new property `mandatoryKeys`,`optionalKeys` and `numberOfSignatures` under the key `keys` to every account in the network as follows:
 
 [source,typescript]
 ----


### PR DESCRIPTION
Wrong module name used in the description. "token module" used, but should be "keys module".