### PR TITLE
Something wrong with `--sender-publickey=sender-publickey`

### DIFF
--- a/modules/ROOT/pages/management/account-management.adoc
+++ b/modules/ROOT/pages/management/account-management.adoc
@@ -86,7 +86,7 @@ OPTIONS
                                            	Examples:
                                            	- --passphrase='my secret passphrase' (should only be used where security is not important)
 
-  -s, --sender-publickey=sender-publickey  Creates the transaction with provided sender publickey, when passphrase is not provided
+  -s, `--sender-publickey=sender-publickey`  Creates the transaction with provided sender publickey, when passphrase is not provided
 
   --network-identifier=network-identifier  Network identifier defined for the network or main | test for the Lisk Network.
 


### PR DESCRIPTION
Hi,

Please check `--sender-publickey=sender-publickey` option. It doesn't work:
`Error: Sender public key must be specified when no-signature flags is used`.
While `-s` option works.

Sample (doesn't work):
`lisk-core transaction:create 2 0 2000000 --json --network testnet --no-signature --sender-publickey 1ebccbd269bf7a276c4207b25eff2c5d89229e7830aed49962eeab8be547a343 --pretty --asset='{"amount":300000000,"recipientAddress":"b537f4e7974be156ee46f13eeb62048ea5909d28","data":"send token"}'`

Sample (works fine):
`lisk-core transaction:create 2 0 2000000 --json --network testnet --no-signature -s 1ebccbd269bf7a276c4207b25eff2c5d89229e7830aed49962eeab8be547a343 --pretty --asset='{"amount":300000000,"recipientAddress":"b537f4e7974be156ee46f13eeb62048ea5909d28","data":"send token"}'`