### PR TITLE
Make sure user installs MySQL 5.7

### DIFF
--- a/modules/ROOT/pages/setup/source.adoc
+++ b/modules/ROOT/pages/setup/source.adoc
@@ -174,7 +174,7 @@ Ubuntu::
 [source,bash]
 ----
 sudo apt update
-sudo apt install mysql-server
+`sudo apt install mysql-server`
 sudo mysql_secure_installation
 ----
 --


### PR DESCRIPTION
Currently, `sudo apt install mysql-server` will install MySQL 8.0. I am not sure for Ubuntu 16-18, but on Ubuntu 20, it does.
Lisk Service does not work with MySQL 8.0. I recommend to clarify user must have 5.7 version and provide instructions on how to do it. It is not obvious.
Also, clarify user must create user `lisk` and a database for MySQL _manually_, the Lisk Service will not do it.