### PR TITLE
More info about EXCHANGERATESAPI_IO_API_KEY

### DIFF
--- a/modules/ROOT/pages/references/configuration.adoc
+++ b/modules/ROOT/pages/references/configuration.adoc
@@ -197,7 +197,7 @@ SERVICE_MARKET_TARGET_PAIRS=LSK_BTC,LSK_EUR,BTC_CHF
 
 # Optional API key for https://exchangeratesapi.io/
 # Used to calculate Fiat exchange rates
-EXCHANGERATESAPI_IO_API_KEY=EXCHANGERATESAPI_IO_API_KEY
+`EXCHANGERATESAPI_IO_API_KEY=EXCHANGERATESAPI_IO_API_KEY`
 
 # Local Redis cache for the Market microservice
 # Required, if Lisk Service is not running in Docker


### PR DESCRIPTION
Hi,
I am confused about `EXCHANGERATESAPI_IO_API_KEY` option.
First, `/market/prices` works even with no `EXCHANGERATESAPI_IO_API_KEY` option set. Where this data comes from then?
Second, what benefits makes setting `EXCHANGERATESAPI_IO_API_KEY` option?
Third, what pricing plan Lisk Service expects from https://exchangeratesapi.io/pricing/?