### PR TITLE
Add punishment explanations to unlock transaction - Closes #1191

### DIFF
--- a/modules/protocol/pages/transactions.adoc
+++ b/modules/protocol/pages/transactions.adoc
@@ -148,9 +148,10 @@ For self-votes, i.e. if the `delegateAddress` property of the transaction is equ
 
 As described in the xref:{url_consensus_bft_punishment}[Punishment of Lisk-BFT protocol violations] section, the validity of the unlock transaction also depends on potential misbehaviors by the unvoted delegate. 
 An unvote for a punished delegate has its unlocking period extended. 
-For regular votes, this period is extended from 2000 blocks to 260,000 blocks (from approximately 5 hours to 1 month).
-For self-votes, this period is extended from 260,000 blocks to 780,000 blocks (from approximately 1 month to 3 months).
-This affects any amount used by the account to vote for the punished delegate or amounts that were used for voting for the punished delegate, but were still in the unlocking period at the inclusion height of the proof-of-misbehavior.
+For regular votes, this period is extended from 2000 blocks to 260,000 blocks (from 5 hours to 30 days).
+For self-votes, this period is extended from 260,000 blocks to 780,000 blocks (from 30 days to 3 months).
+This affects any amount currently voting for the punished delegate or amounts that were used for voting for this delegate, but were still in the unlocking period at the inclusion height of the proof-of-misbehavior.
+
 
 [[multisignature]]
 === Multisignature group registration

--- a/modules/protocol/pages/transactions.adoc
+++ b/modules/protocol/pages/transactions.adoc
@@ -146,6 +146,12 @@ This transaction is only valid if it is issued after the unlocking period has be
 For a regular vote the unlocking period is 2000 blocks (around 5 hours).
 For self-votes, i.e. if the `delegateAddress` property of the transaction is equal to the account xref:{url_accounts_address}[address], this period is 260,000 blocks (around 30 days).
 
+As described in the xref:{url_consensus_bft_punishment}[Punishment of Lisk-BFT protocol violations] section, the validity of the unlock transaction also depends on potential misbehaviors by the unvoted delegate. 
+An unvote for a punished delegate has its unlocking period extended. 
+For regular votes, this period is extended from 2000 blocks to 260,000 blocks (from approximately 5 hours to 1 month).
+For self-votes, this period is extended from 260,000 blocks to 780,000 blocks (from approximately 1 month to 3 months).
+This affects any amount used by the account to vote for the punished delegate or amounts that were used for voting for the punished delegate, but were still in the unlocking period at the inclusion height of the proof-of-misbehavior.
+
 [[multisignature]]
 === Multisignature group registration
 


### PR DESCRIPTION
Add content describing the modification of the unlock validity regarding delegate punishment.
Closes #1191 .