### PR TITLE
Update cryptography.adoc

### DIFF
--- a/modules/ROOT/pages/references/lisk-elements/cryptography.adoc
+++ b/modules/ROOT/pages/references/lisk-elements/cryptography.adoc
@@ -837,7 +837,7 @@ Returns an account address as a Buffer for a given Lisk32 address.
 
 [source,js]
 ----
-getLisk32AddressFromAddress(Lisk32Address,prefix)
+getLisk32AddressFromAddress(address,prefix)
 ----
 
 ==== Parameters


### PR DESCRIPTION
Wrong parameter in `getLisk32AddressFromAddress` syntax