### PR TITLE
 fixed wrong type in config.json #1630 

### DIFF
--- a/docs/modules/ROOT/pages/build-blockchain/configure-app.adoc
+++ b/docs/modules/ROOT/pages/build-blockchain/configure-app.adoc
@@ -159,7 +159,7 @@ TIP: To see a full list of all constants and their predefined values, please see
             {
                 "moduleID": 2,
                 "assetID": 0,
-                "baseFee": 1000000
+                "baseFee": "1000000"
             }
         ],
         "activeDelegates": 31,


### PR DESCRIPTION
The page [How to configure a blockchain application](https://lisk.com/documentation/build-blockchain/configure-app.html) indicated the user to copy a configuration, but the type for `.genesisConfig.baseFees.0.baseFee` is a string and in the current example it is set as a number.

If you copy and paste the current implementation it will throw an error:
```
Error: Lisk validator found 1 error[s]:
Property '.genesisConfig.baseFees.0.baseFee' should be of type 'string'
```

This should fix that issue. 