### PR TITLE
Typo in method name of API client - closes 1631

### DIFF
--- a/modules/ROOT/pages/references/lisk-elements/api-client.adoc
+++ b/modules/ROOT/pages/references/lisk-elements/api-client.adoc
@@ -74,7 +74,7 @@ interface APIClient {
     fromJSON(transaction: Record<string, unknown>) => Record<string, unknown>;
   }
   public node: {
-    getInfo: () => Promise<Record<string, unknown>>;
+    getNodeInfo: () => Promise<Record<string, unknown>>;
     getNetworkStats: () => Promise<Record<string, unknown>>;
     getConnectedPeers: () => Promise<Peer[]>;
     getDisconnectedPeers: () => Promise<Peer[]>;


### PR DESCRIPTION
Closes #1631 